### PR TITLE
Context proof of concept

### DIFF
--- a/examples/ex1.rs
+++ b/examples/ex1.rs
@@ -10,8 +10,13 @@ statemachine! {
     State2 + Event2 = State3,
 }
 
+#[derive(Debug, Default)]
+pub struct Context;
+
+impl StateMachineContext for Context {}
+
 fn main() {
-    let mut sm = StateMachine::new();
+    let mut sm = StateMachine::<Context>::new();
     assert_eq!(sm.state(), States::State1);
 
     let r = sm.process_event(Events::Event1);

--- a/examples/ex2.rs
+++ b/examples/ex2.rs
@@ -11,8 +11,13 @@ statemachine! {
     State3 + Event3 = State2,
 }
 
+#[derive(Debug, Default)]
+pub struct Context;
+
+impl StateMachineContext for Context {}
+
 fn main() {
-    let mut sm = StateMachine::new();
+    let mut sm = StateMachine::<Context>::new();
     assert_eq!(sm.state(), States::State1);
 
     let r = sm.process_event(Events::Event1);

--- a/examples/ex3.rs
+++ b/examples/ex3.rs
@@ -10,26 +10,31 @@ statemachine! {
     State2 + Event2 [guard_fail] / action2 = State3,
 }
 
-fn guard() -> bool {
-    // Always ok
-    true
-}
+#[derive(Debug, Default)]
+pub struct Context;
 
-fn guard_fail() -> bool {
-    // Always fail
-    false
-}
+impl StateMachineContext for Context {
+    fn guard(&self) -> bool {
+        // Always ok
+        true
+    }
 
-fn action1() {
-    println!("Action 1");
-}
+    fn guard_fail(&self) -> bool {
+        // Always fail
+        false
+    }
 
-fn action2() {
-    println!("Action 1");
+    fn action1(&self) {
+        println!("Action 1");
+    }
+
+    fn action2(&self) {
+        println!("Action 1");
+    }
 }
 
 fn main() {
-    let mut sm = StateMachine::new();
+    let mut sm = StateMachine::<Context>::new();
     assert_eq!(sm.state(), States::State1);
 
     println!("Before action 1");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,34 @@
 use smlang_macros::statemachine;
 
-fn guard1() -> bool {
-    //println!("Guard 1 ok");
+#[derive(Debug, Default)]
+pub struct Context;
 
-    true
-}
+impl StateMachineContext for Context {
+    fn guard1(&self) -> bool {
+        //println!("Guard 1 ok");
 
-fn guard2() -> bool {
-    //println!("Guard 2 ok");
+        true
+    }
 
-    true
-}
+    fn guard2(&self) -> bool {
+        //println!("Guard 2 ok");
 
-fn guard_fail() -> bool {
-    //println!("Guard 2 ok");
+        true
+    }
 
-    true
-}
+    fn guard_fail(&self) -> bool {
+        //println!("Guard 2 ok");
 
-fn action1() {
-    //println!("Running Action 1");
-}
+        true
+    }
 
-fn action2() {
-    //println!("Running Action 2");
+    fn action1(&self) {
+        //println!("Running Action 1");
+    }
+
+    fn action2(&self) {
+        //println!("Running Action 2");
+    }
 }
 
 // Transition DSL (from Boost-SML):
@@ -40,7 +45,7 @@ statemachine!(
 );
 
 fn main() {
-    let mut sm = StateMachine::new();
+    let mut sm = StateMachine::<Context>::new();
     // assert_eq!(sm.state(), States::State1);
 
     let _ = sm.process_event(Events::Event1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,27 +1,32 @@
 use super::statemachine;
 
-fn guard1() -> bool {
-    println!("Guard 1 ok");
+#[derive(Debug, Default)]
+pub struct Context;
 
-    true
-}
+impl StateMachineContext for Context {
+    fn guard1(&self) -> bool {
+        println!("Guard 1 ok");
 
-fn guard2() -> bool {
-    println!("Guard 2 ok");
+        true
+    }
 
-    true
-}
+    fn guard2(&self) -> bool {
+        println!("Guard 2 ok");
 
-fn guard_fail() -> bool {
-    false
-}
+        true
+    }
 
-fn action1() {
-    println!("Running Action 1");
-}
+    fn guard_fail(&self) -> bool {
+        false
+    }
 
-fn action2() {
-    println!("Running Action 2");
+    fn action1(&self) {
+        println!("Running Action 1");
+    }
+
+    fn action2(&self) {
+        println!("Running Action 2");
+    }
 }
 
 statemachine!(
@@ -34,13 +39,13 @@ statemachine!(
 
 #[test]
 fn starting_state() {
-    let sm = StateMachine::new();
+    let sm = StateMachine::<Context>::new();
     assert_eq!(sm.state(), States::State1);
 }
 
 #[test]
 fn transitions() {
-    let mut sm = StateMachine::new();
+    let mut sm = StateMachine::<Context>::new();
 
     let _ = sm.process_event(Events::Event1);
     assert_eq!(sm.state(), States::State2);
@@ -81,7 +86,7 @@ fn transitions() {
 
 #[test]
 fn event_error() {
-    let mut sm = StateMachine::new();
+    let mut sm = StateMachine::<Context>::new();
     assert_eq!(sm.state(), States::State1);
 
     let output = sm.process_event(Events::Event3);
@@ -93,7 +98,7 @@ fn event_error() {
 
 #[test]
 fn guard_error() {
-    let mut sm = StateMachine::new();
+    let mut sm = StateMachine::<Context>::new();
 
     let _ = sm.process_event(Events::Event1);
     let output = sm.process_event(Events::Event4);


### PR DESCRIPTION
Possible solution to #2 

This is a proof of concept solution for having guard/transition methods have access to some user-defined context. At a high level, all guard/action methods get placed into a context trait (currently hardcoded as `StateMachineContext`) which the user would implement on their own type.