### PR TITLE
Allow for using the same action in multiple transitions

### DIFF
--- a/examples/guard_action_syntax_with_temporary_context.rs
+++ b/examples/guard_action_syntax_with_temporary_context.rs
@@ -56,7 +56,9 @@ fn main() {
     let mut val = 0;
 
     // This invocation will go through 1 guard and one action.
-    let r = sm.process_event(&mut val, Events::Event1(MyEventData(1))).unwrap();
+    let r = sm
+        .process_event(&mut val, Events::Event1(MyEventData(1)))
+        .unwrap();
 
     assert!(r == &States::State2(MyStateData(1)));
     assert_eq!(val, 2);

--- a/examples/reuse_action.rs
+++ b/examples/reuse_action.rs
@@ -1,0 +1,42 @@
+//! Reuse the same aciton more than once
+//!
+//! This example shows how to use the same action in multiple transitions.
+
+#![deny(missing_docs)]
+
+use smlang::statemachine;
+
+statemachine! {
+    *State1 + Event1 / action = State2,
+    State1 + Event2 / action = State3,
+    State2 + Event2 = State1,
+}
+
+/// Action will increment our context
+pub struct Context(usize);
+
+impl StateMachineContext for Context {
+    fn action(&mut self) {
+        self.0 += 1;
+    }
+}
+
+fn main() {
+    let mut sm = StateMachine::new(Context(0));
+    assert!(sm.state() == &States::State1);
+    assert!(sm.context.0 == 0);
+
+    // triggers action
+    let r = sm.process_event(Events::Event1);
+    assert!(r == Ok(&States::State2));
+    assert!(sm.context.0 == 1);
+
+    let r = sm.process_event(Events::Event2);
+    assert!(r == Ok(&States::State1));
+    assert!(sm.context.0 == 1);
+
+    // triggers the same action
+    let r = sm.process_event(Events::Event2);
+    assert!(r == Ok(&States::State3));
+    assert!(sm.context.0 == 2);
+}


### PR DESCRIPTION
Thanks for this cool library!

In my state machine I have multiple state transitions that require running the same action, but in the current implementation of `smlang-rs` it results in multiple definitions of an action with the same name in the `StateMachineContext` trait, so I have to use different name and write some boilerplate code.

I added changes that will allow to use the same action name multiple times and generate only a single method for them. Do you think this is a good feature? My actions/states do not carry any additional data. I guess that with this changes, when someone tries to have to actions that would require different signatures, then the compilation will just fail.

One other thing is that it would be nice if it was possible to derive the `Debug` trait for `Events`/`States` (always? or configurable?). It greatly improves debugging of the state machine behavior and currently I have to implement the trait manually. I also implement `Clone` for `States` manually (as my state has no data so could even by `Copy`). I'm not sure how much effort would it be to be able to also derive it. Maybe some kind of a special syntax at the beginning of the macro?