### PR TITLE
Allow referenced event data to be &mut reference

### DIFF
--- a/examples/event_with_mutable_data.rs
+++ b/examples/event_with_mutable_data.rs
@@ -1,0 +1,38 @@
+//! Event data example
+//!
+//! An example of using event data together with a guard and action.
+
+#![deny(missing_docs)]
+
+use smlang::statemachine;
+
+/// Event data
+#[derive(PartialEq)]
+pub struct MyEventData(pub u32);
+
+statemachine! {
+    *State1 + Event1(&'a mut MyEventData) [guard] / action = State2,
+    // ...
+}
+
+/// Context
+pub struct Context;
+
+impl StateMachineContext for Context {
+    fn guard(&mut self, event_data: &mut MyEventData) -> bool {
+        event_data.0 = 55;
+        true
+    }
+
+    fn action(&mut self, event_data: &mut MyEventData) {
+        println!("Got valid Event Data = {}", event_data.0);
+    }
+}
+
+fn main() {
+    let mut sm = StateMachine::new(Context);
+
+    let result = sm.process_event(Events::Event1(&mut MyEventData(42))); // Guard will pass
+
+    assert!(result == Ok(&States::State2));
+}

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -87,7 +87,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
                         }
                         Some(_) => {
                             quote! {
-                                #value(ref event_data)
+                                #value(ref mut event_data)
                             }
                         }
                     }
@@ -442,7 +442,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
             ///
             /// It will return `Ok(&NextState)` if the transition was successful, or `Err(Error)`
             /// if there was an error in the transition.
-            pub fn process_event(&mut self, #temporary_context event: Events) -> Result<&States, Error> {
+            pub fn process_event(&mut self, #temporary_context mut event: Events) -> Result<&States, Error> {
                 match self.state {
                     #(States::#in_states => match event {
                         #(Events::#events => {


### PR DESCRIPTION
This is useful for example for inplace decoding of data.

Fixes #13 