### PR TITLE
Support custom guard errors

### DIFF
--- a/examples/context.rs
+++ b/examples/context.rs
@@ -7,8 +7,10 @@
 use smlang::statemachine;
 
 statemachine! {
-    *State1 + Event1 / count_transition1 = State2,
-    State2 + Event2 / count_transition2 = State1,
+    transitions: {
+        *State1 + Event1 / count_transition1 = State2,
+        State2 + Event2 / count_transition2 = State1,
+    }
 }
 
 /// Context with member

--- a/examples/event_with_data.rs
+++ b/examples/event_with_data.rs
@@ -11,16 +11,22 @@ use smlang::statemachine;
 pub struct MyEventData(pub u32);
 
 statemachine! {
-    *State1 + Event1(MyEventData) [guard] / action = State2,
-    // ...
+    transitions: {
+        *State1 + Event1(MyEventData) [guard] / action = State2,
+        // ...
+    }
 }
 
 /// Context
 pub struct Context;
 
 impl StateMachineContext for Context {
-    fn guard(&mut self, event_data: &MyEventData) -> bool {
-        event_data == &MyEventData(42)
+    fn guard(&mut self, event_data: &MyEventData) -> Result<(), ()> {
+        if event_data == &MyEventData(42) {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     fn action(&mut self, event_data: &MyEventData) {
@@ -32,7 +38,7 @@ fn main() {
     let mut sm = StateMachine::new(Context);
     let result = sm.process_event(Events::Event1(MyEventData(1))); // Guard will fail
 
-    assert!(result == Err(Error::GuardFailed));
+    assert!(result == Err(Error::GuardFailed(())));
 
     let result = sm.process_event(Events::Event1(MyEventData(42))); // Guard will pass
 

--- a/examples/event_with_mutable_data.rs
+++ b/examples/event_with_mutable_data.rs
@@ -11,17 +11,19 @@ use smlang::statemachine;
 pub struct MyEventData(pub u32);
 
 statemachine! {
-    *State1 + Event1(&'a mut MyEventData) [guard] / action = State2,
-    // ...
+    transitions: {
+        *State1 + Event1(&'a mut MyEventData) [guard] / action = State2,
+        // ...
+    }
 }
 
 /// Context
 pub struct Context;
 
 impl StateMachineContext for Context {
-    fn guard(&mut self, event_data: &mut MyEventData) -> bool {
+    fn guard(&mut self, event_data: &mut MyEventData) -> Result<(), ()> {
         event_data.0 = 55;
-        true
+        Ok(())
     }
 
     fn action(&mut self, event_data: &mut MyEventData) {

--- a/examples/event_with_reference_data.rs
+++ b/examples/event_with_reference_data.rs
@@ -11,25 +11,35 @@ use smlang::statemachine;
 pub struct MyReferenceWrapper<'a>(pub &'a u32);
 
 statemachine! {
-    *State1 + Event1(&'a [u8]) [guard1] / action1 = State2,
-    State2 + Event2(MyReferenceWrapper<'b>) [guard2] / action2 = State3,
+    transitions: {
+        *State1 + Event1(&'a [u8]) [guard1] / action1 = State2,
+        State2 + Event2(MyReferenceWrapper<'b>) [guard2] / action2 = State3,
+    }
 }
 
 /// Context
 pub struct Context;
 
 impl StateMachineContext for Context {
-    fn guard1(&mut self, event_data: &[u8]) -> bool {
+    fn guard1(&mut self, event_data: &[u8]) -> Result<(), ()> {
         // Only ok if the slice is not empty
-        !event_data.is_empty()
+        if !event_data.is_empty() {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     fn action1(&mut self, event_data: &[u8]) {
         println!("Got valid Event Data = {:?}", event_data);
     }
 
-    fn guard2(&mut self, event_data: &MyReferenceWrapper) -> bool {
-        *event_data.0 > 9000
+    fn guard2(&mut self, event_data: &MyReferenceWrapper) -> Result<(), ()> {
+        if *event_data.0 > 9000 {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     fn action2(&mut self, event_data: &MyReferenceWrapper) {
@@ -41,13 +51,13 @@ fn main() {
     let mut sm = StateMachine::new(Context);
 
     let result = sm.process_event(Events::Event1(&[])); // Guard will fail
-    assert!(result == Err(Error::GuardFailed));
+    assert!(result == Err(Error::GuardFailed(())));
     let result = sm.process_event(Events::Event1(&[1, 2, 3])); // Guard will pass
     assert!(result == Ok(&States::State2));
 
     let r = 42;
     let result = sm.process_event(Events::Event2(MyReferenceWrapper(&r))); // Guard will fail
-    assert!(result == Err(Error::GuardFailed));
+    assert!(result == Err(Error::GuardFailed(())));
 
     let r = 9001;
     let result = sm.process_event(Events::Event2(MyReferenceWrapper(&r))); // Guard will pass

--- a/examples/ex1.rs
+++ b/examples/ex1.rs
@@ -8,8 +8,10 @@
 use smlang::statemachine;
 
 statemachine! {
-    *State1 + Event1 = State2,
-    State2 + Event2 = State3,
+    transitions: {
+        *State1 + Event1 = State2,
+        State2 + Event2 = State3,
+    },
 }
 
 /// Context

--- a/examples/ex2.rs
+++ b/examples/ex2.rs
@@ -8,9 +8,11 @@
 use smlang::statemachine;
 
 statemachine! {
-    *State1 + Event1 = State2,
-    State2 + Event2 = State3,
-    State3 + Event3 = State2,
+    transitions: {
+        *State1 + Event1 = State2,
+        State2 + Event2 = State3,
+        State3 + Event3 = State2,
+    }
 }
 
 /// Context

--- a/examples/ex3.rs
+++ b/examples/ex3.rs
@@ -8,22 +8,24 @@
 use smlang::statemachine;
 
 statemachine! {
-    *State1 + Event1 [guard] / action1 = State2,
-    State2 + Event2 [guard_fail] / action2 = State3,
+    transitions: {
+        *State1 + Event1 [guard] / action1 = State2,
+        State2 + Event2 [guard_fail] / action2 = State3,
+    }
 }
 
 /// Context
 pub struct Context;
 
 impl StateMachineContext for Context {
-    fn guard(&mut self) -> bool {
+    fn guard(&mut self) -> Result<(), ()> {
         // Always ok
-        true
+        Ok(())
     }
 
-    fn guard_fail(&mut self) -> bool {
+    fn guard_fail(&mut self) -> Result<(), ()> {
         // Always fail
-        false
+        Err(())
     }
 
     fn action1(&mut self) {
@@ -51,7 +53,7 @@ fn main() {
 
     // The action will never run as the guard will fail
     let r = sm.process_event(Events::Event2);
-    assert!(r == Err(Error::GuardFailed));
+    assert!(r == Err(Error::GuardFailed(())));
 
     println!("After action 2");
 

--- a/examples/guard_action_syntax_with_temporary_context.rs
+++ b/examples/guard_action_syntax_with_temporary_context.rs
@@ -15,9 +15,12 @@ pub struct MyEventData(pub u32);
 pub struct MyStateData(pub u32);
 
 statemachine! {
-    *(&mut u16) State1 + Event1(MyEventData) [guard1] / action1 = State2,
-    State2(MyStateData) + Event2  [guard2] / action2 = State3,
-    // ...
+    temporary_context: &mut u16,
+    transitions: {
+        *State1 + Event1(MyEventData) [guard1] / action1 = State2,
+        State2(MyStateData) + Event2  [guard2] / action2 = State3,
+        // ...
+    },
 }
 
 /// Context
@@ -25,10 +28,10 @@ pub struct Context;
 
 impl StateMachineContext for Context {
     // Guard1 has access to the data from Event1
-    fn guard1(&mut self, temp_context: &mut u16, _event_data: &MyEventData) -> bool {
+    fn guard1(&mut self, temp_context: &mut u16, _event_data: &MyEventData) -> Result<(), ()> {
         *temp_context += 1;
 
-        true
+        Ok(())
     }
 
     // Action1 has access to the data from Event1, and need to return the state data for State2
@@ -39,10 +42,10 @@ impl StateMachineContext for Context {
     }
 
     // Guard2 has access to the data from State2
-    fn guard2(&mut self, temp_context: &mut u16, _state_data: &MyStateData) -> bool {
+    fn guard2(&mut self, temp_context: &mut u16, _state_data: &MyStateData) -> Result<(), ()> {
         *temp_context += 1;
 
-        true
+        Ok(())
     }
 
     // Action2 has access to the data from State2

--- a/examples/guard_custom_error.rs
+++ b/examples/guard_custom_error.rs
@@ -6,6 +6,15 @@
 
 use smlang::statemachine;
 
+
+/// Custom guard errors
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardError {
+    /// This is a custom guard error variant
+    Custom
+}
+
+
 /// Event data
 #[derive(PartialEq)]
 pub struct MyEventData(pub u32);
@@ -19,7 +28,8 @@ statemachine! {
         *State1 + Event1(MyEventData) [guard1] / action1 = State2,
         State2(MyStateData) + Event2  [guard2] / action2 = State3,
         // ...
-    }
+    },
+    guard_error: GuardError,
 }
 
 /// Context
@@ -27,8 +37,8 @@ pub struct Context;
 
 impl StateMachineContext for Context {
     // Guard1 has access to the data from Event1
-    fn guard1(&mut self, _event_data: &MyEventData) -> Result<(), ()> {
-        todo!()
+    fn guard1(&mut self, _event_data: &MyEventData) -> Result<(), GuardError> {
+        Err(GuardError::Custom)
     }
 
     // Action1 has access to the data from Event1, and need to return the state data for State2
@@ -37,7 +47,7 @@ impl StateMachineContext for Context {
     }
 
     // Guard2 has access to the data from State2
-    fn guard2(&mut self, _state_data: &MyStateData) -> Result<(), ()> {
+    fn guard2(&mut self, _state_data: &MyStateData) -> Result<(), GuardError> {
         todo!()
     }
 

--- a/examples/guard_custom_error.rs
+++ b/examples/guard_custom_error.rs
@@ -6,14 +6,12 @@
 
 use smlang::statemachine;
 
-
 /// Custom guard errors
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuardError {
     /// This is a custom guard error variant
-    Custom
+    Custom,
 }
-
 
 /// Event data
 #[derive(PartialEq)]

--- a/examples/reuse_action.rs
+++ b/examples/reuse_action.rs
@@ -7,9 +7,11 @@
 use smlang::statemachine;
 
 statemachine! {
-    *State1 + Event1 / action = State2,
-    State1 + Event2 / action = State3,
-    State2 + Event2 = State1,
+    transitions: {
+        *State1 + Event1 / action = State2,
+        State1 + Event2 / action = State3,
+        State2 + Event2 = State1,
+    }
 }
 
 /// Action will increment our context

--- a/examples/state_with_data.rs
+++ b/examples/state_with_data.rs
@@ -11,9 +11,11 @@ use smlang::statemachine;
 pub struct MyStateData(pub u32);
 
 statemachine! {
-    *State1 + Event1 / action = State2,
-    State2(MyStateData) + Event2 = State1,
-    // ...
+    transitions: {
+        *State1 + Event1 / action = State2,
+        State2(MyStateData) + Event2 = State1,
+        // ...
+    }
 }
 
 /// Context

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -391,7 +391,6 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
 
     let guard_failed = if let Some(ref guard_error) = sm.guard_error {
         quote! { GuardFailed(#guard_error) }
-
     } else {
         quote! { GuardFailed(()) }
     };

--- a/macros/src/parser.rs
+++ b/macros/src/parser.rs
@@ -270,7 +270,7 @@ impl parse::Parse for StateTransition {
     fn parse(input: parse::ParseStream) -> syn::Result<Self> {
         // Check for starting state definition
         let start = input.parse::<Token![*]>().is_ok();
-        
+
         // Parse the DSL
         //
         // Transition DSL:
@@ -433,12 +433,12 @@ impl parse::Parse for StateMachine {
 
                             let transition: StateTransition = content.parse()?;
                             statemachine.add_transition(transition);
-                            
+
                             // No comma at end of line, no more transitions
                             if content.is_empty() {
                                 break;
                             }
-                            
+
                             if let Err(_) = content.parse::<Token![,]>() {
                                 break;
                             };
@@ -464,13 +464,13 @@ impl parse::Parse for StateMachine {
                             ))
                         }
                     }
-                    
+
                     statemachine.guard_error = Some(guard_error);
                 }
                 "temporary_context" => {
                     input.parse::<Token![:]>()?;
                     let temporary_context_type: Type = input.parse()?;
-    
+
                     // Check so the type is supported
                     match &temporary_context_type {
                         Type::Array(_)
@@ -486,7 +486,7 @@ impl parse::Parse for StateMachine {
                             ))
                         }
                     }
-    
+
                     // Store the temporary context type
                     statemachine.temporary_context_type = Some(temporary_context_type);
 
@@ -498,7 +498,6 @@ impl parse::Parse for StateMachine {
                     ))
                 }
             }
-            
 
             // No comma at end of line, no more transitions
             if input.is_empty() {

--- a/macros/src/parser.rs
+++ b/macros/src/parser.rs
@@ -1,13 +1,14 @@
 use proc_macro2::Span;
 use std::collections::HashMap;
 use syn::{
-    bracketed, parenthesized, parse, spanned::Spanned, token, GenericArgument, Ident, Lifetime,
-    PathArguments, Token, Type,
+    braced, bracketed, parenthesized, parse, spanned::Spanned, token, GenericArgument, Ident,
+    Lifetime, PathArguments, Token, Type,
 };
 
 #[derive(Debug)]
 pub struct StateMachine {
     pub temporary_context_type: Option<Type>,
+    pub guard_error: Option<Type>,
     pub transitions: Vec<StateTransition>,
 }
 
@@ -15,6 +16,7 @@ impl StateMachine {
     pub fn new() -> Self {
         StateMachine {
             temporary_context_type: None,
+            guard_error: None,
             transitions: Vec::new(),
         }
     }
@@ -35,6 +37,7 @@ pub struct EventMapping {
 #[derive(Debug)]
 pub struct ParsedStateMachine {
     pub temporary_context_type: Option<Type>,
+    pub guard_error: Option<Type>,
     pub states: HashMap<String, Ident>,
     pub starting_state: Ident,
     pub state_data_type: HashMap<String, Type>,
@@ -237,6 +240,7 @@ impl ParsedStateMachine {
 
         Ok(ParsedStateMachine {
             temporary_context_type: sm.temporary_context_type,
+            guard_error: sm.guard_error,
             states,
             starting_state,
             state_data_type,
@@ -262,6 +266,150 @@ pub struct StateTransition {
     out_state_data_type: Option<Type>,
 }
 
+impl parse::Parse for StateTransition {
+    fn parse(input: parse::ParseStream) -> syn::Result<Self> {
+        // Check for starting state definition
+        let start = input.parse::<Token![*]>().is_ok();
+        
+        // Parse the DSL
+        //
+        // Transition DSL:
+        // SrcState(OptionalType1) + Event(OptionalType2) [ guard ] / action =
+        // DstState(OptionalType3)
+
+        // Input State
+        let in_state: Ident = input.parse()?;
+
+        // Possible type on the input state
+        let in_state_data_type = if input.peek(token::Paren) {
+            let content;
+            parenthesized!(content in input);
+            let input: Type = content.parse()?;
+
+            // Check if this is the starting state, it cannot have data as there is no
+            // supported way of propagating it (for now)
+            if start {
+                return Err(parse::Error::new(
+                    input.span(),
+                    "The starting state cannot have data associated with it.",
+                ));
+            }
+
+            // Check so the type is supported
+            match &input {
+                Type::Array(_)
+                | Type::Path(_)
+                | Type::Ptr(_)
+                | Type::Reference(_)
+                | Type::Slice(_)
+                | Type::Tuple(_) => (),
+                _ => {
+                    return Err(parse::Error::new(
+                        input.span(),
+                        "This is an unsupported type for states.",
+                    ))
+                }
+            }
+
+            Some(input)
+        } else {
+            None
+        };
+
+        // Event
+        input.parse::<Token![+]>()?;
+        let event: Ident = input.parse()?;
+
+        // Possible type on the event
+        let event_data_type = if input.peek(token::Paren) {
+            let content;
+            parenthesized!(content in input);
+            let input: Type = content.parse()?;
+
+            // Check so the type is supported
+            match &input {
+                Type::Array(_)
+                | Type::Path(_)
+                | Type::Ptr(_)
+                | Type::Reference(_)
+                | Type::Slice(_)
+                | Type::Tuple(_) => (),
+                _ => {
+                    return Err(parse::Error::new(
+                        input.span(),
+                        "This is an unsupported type for events.",
+                    ))
+                }
+            }
+
+            Some(input)
+        } else {
+            None
+        };
+
+        // Possible guard
+        let guard = if input.peek(token::Bracket) {
+            let content;
+            bracketed!(content in input);
+            let guard: Ident = content.parse()?;
+            Some(guard)
+        } else {
+            None
+        };
+
+        // Possible action
+        let action = if let Ok(_) = input.parse::<Token![/]>() {
+            let action: Ident = input.parse()?;
+            Some(action)
+        } else {
+            None
+        };
+
+        input.parse::<Token![=]>()?;
+
+        let out_state: Ident = input.parse()?;
+
+        // Possible type on the input state
+        let out_state_data_type = if input.peek(token::Paren) {
+            let content;
+            parenthesized!(content in input);
+            let input: Type = content.parse()?;
+
+            // Check so the type is supported
+            match &input {
+                Type::Array(_)
+                | Type::Path(_)
+                | Type::Ptr(_)
+                | Type::Reference(_)
+                | Type::Slice(_)
+                | Type::Tuple(_) => (),
+                _ => {
+                    return Err(parse::Error::new(
+                        input.span(),
+                        "This is an unsupported type for states.",
+                    ))
+                }
+            }
+
+            Some(input)
+        } else {
+            None
+        };
+
+        Ok(StateTransition {
+            start,
+            in_state,
+            in_state_data_type,
+            event,
+            event_data_type,
+            guard,
+            action,
+            out_state,
+            out_state_data_type,
+        })
+    }
+}
+
 impl parse::Parse for StateMachine {
     fn parse(input: parse::ParseStream) -> parse::Result<Self> {
         let mut statemachine = StateMachine::new();
@@ -272,16 +420,37 @@ impl parse::Parse for StateMachine {
                 break;
             }
 
-            // Check for starting state definition
-            let start = if let Ok(_) = input.parse::<Token![*]>() {
-                // Check for the temporary context
-                if input.peek(token::Paren) {
-                    let content;
-                    parenthesized!(content in input);
-                    let input: Type = content.parse()?;
+            match input.parse::<Ident>()?.to_string().as_str() {
+                "transitions" => {
+                    input.parse::<Token![:]>()?;
+                    if input.peek(token::Brace) {
+                        let content;
+                        braced!(content in input);
+                        loop {
+                            if content.is_empty() {
+                                break;
+                            }
+
+                            let transition: StateTransition = content.parse()?;
+                            statemachine.add_transition(transition);
+                            
+                            // No comma at end of line, no more transitions
+                            if content.is_empty() {
+                                break;
+                            }
+                            
+                            if let Err(_) = content.parse::<Token![,]>() {
+                                break;
+                            };
+                        }
+                    }
+                }
+                "guard_error" => {
+                    input.parse::<Token![:]>()?;
+                    let guard_error: Type = input.parse()?;
 
                     // Check so the type is supported
-                    match &input {
+                    match &guard_error {
                         Type::Array(_)
                         | Type::Path(_)
                         | Type::Ptr(_)
@@ -290,158 +459,46 @@ impl parse::Parse for StateMachine {
                         | Type::Tuple(_) => (),
                         _ => {
                             return Err(parse::Error::new(
-                                input.span(),
+                                guard_error.span(),
+                                "This is an unsupported type for guard error.",
+                            ))
+                        }
+                    }
+                    
+                    statemachine.guard_error = Some(guard_error);
+                }
+                "temporary_context" => {
+                    input.parse::<Token![:]>()?;
+                    let temporary_context_type: Type = input.parse()?;
+    
+                    // Check so the type is supported
+                    match &temporary_context_type {
+                        Type::Array(_)
+                        | Type::Path(_)
+                        | Type::Ptr(_)
+                        | Type::Reference(_)
+                        | Type::Slice(_)
+                        | Type::Tuple(_) => (),
+                        _ => {
+                            return Err(parse::Error::new(
+                                temporary_context_type.span(),
                                 "This is an unsupported type for the temporary state.",
                             ))
                         }
                     }
-
+    
                     // Store the temporary context type
-                    statemachine.temporary_context_type = Some(input);
+                    statemachine.temporary_context_type = Some(temporary_context_type);
+
                 }
-
-                true
-            } else {
-                false
-            };
-
-            //
-            // Parse the DSL
-            //
-            // Transition DSL:
-            // SrcState(OptionalType1) + Event(OptionalType2) [ guard ] / action =
-            // DstState(OptionalType3)
-
-            // Input State
-            let in_state: Ident = input.parse()?;
-
-            // Possible type on the input state
-            let in_state_data_type = if input.peek(token::Paren) {
-                let content;
-                parenthesized!(content in input);
-                let input: Type = content.parse()?;
-
-                // Check if this is the starting state, it cannot have data as there is no
-                // supported way of propagating it (for now)
-                if start {
+                keyword => {
                     return Err(parse::Error::new(
                         input.span(),
-                        "The starting state cannot have data associated with it.",
-                    ));
+                        format!("Unknown keyword {}. Support keywords: [\"transitions\", \"temporary_context\", \"guard_error\"]", keyword)
+                    ))
                 }
-
-                // Check so the type is supported
-                match &input {
-                    Type::Array(_)
-                    | Type::Path(_)
-                    | Type::Ptr(_)
-                    | Type::Reference(_)
-                    | Type::Slice(_)
-                    | Type::Tuple(_) => (),
-                    _ => {
-                        return Err(parse::Error::new(
-                            input.span(),
-                            "This is an unsupported type for states.",
-                        ))
-                    }
-                }
-
-                Some(input)
-            } else {
-                None
-            };
-
-            // Event
-            input.parse::<Token![+]>()?;
-            let event: Ident = input.parse()?;
-
-            // Possible type on the event
-            let event_data_type = if input.peek(token::Paren) {
-                let content;
-                parenthesized!(content in input);
-                let input: Type = content.parse()?;
-
-                // Check so the type is supported
-                match &input {
-                    Type::Array(_)
-                    | Type::Path(_)
-                    | Type::Ptr(_)
-                    | Type::Reference(_)
-                    | Type::Slice(_)
-                    | Type::Tuple(_) => (),
-                    _ => {
-                        return Err(parse::Error::new(
-                            input.span(),
-                            "This is an unsupported type for events.",
-                        ))
-                    }
-                }
-
-                Some(input)
-            } else {
-                None
-            };
-
-            // Possible guard
-            let guard = if input.peek(token::Bracket) {
-                let content;
-                bracketed!(content in input);
-                let guard: Ident = content.parse()?;
-                Some(guard)
-            } else {
-                None
-            };
-
-            // Possible action
-            let action = if let Ok(_) = input.parse::<Token![/]>() {
-                let action: Ident = input.parse()?;
-                Some(action)
-            } else {
-                None
-            };
-
-            input.parse::<Token![=]>()?;
-
-            let out_state: Ident = input.parse()?;
-
-            // Possible type on the input state
-            let out_state_data_type = if input.peek(token::Paren) {
-                let content;
-                parenthesized!(content in input);
-                let input: Type = content.parse()?;
-
-                // Check so the type is supported
-                match &input {
-                    Type::Array(_)
-                    | Type::Path(_)
-                    | Type::Ptr(_)
-                    | Type::Reference(_)
-                    | Type::Slice(_)
-                    | Type::Tuple(_) => (),
-                    _ => {
-                        return Err(parse::Error::new(
-                            input.span(),
-                            "This is an unsupported type for states.",
-                        ))
-                    }
-                }
-
-                Some(input)
-            } else {
-                None
-            };
-
-            statemachine.add_transition(StateTransition {
-                start,
-                in_state,
-                in_state_data_type,
-                event,
-                event_data_type,
-                guard,
-                action,
-                out_state,
-                out_state_data_type,
-            });
+            }
+            
 
             // No comma at end of line, no more transitions
             if input.is_empty() {

--- a/tests/compile-fail/double_state_event.rs
+++ b/tests/compile-fail/double_state_event.rs
@@ -3,8 +3,10 @@ extern crate smlang;
 use smlang::statemachine;
 
 statemachine! {
-    *State1 + Event1 = State2,
-    State1 + Event1 = State3, //~ State and event combination specified multiple times, remove duplicates.
+    transitions: {
+        *State1 + Event1 = State2,
+        State1 + Event1 = State3, //~ State and event combination specified multiple times, remove duplicates.
+    }
 }
 
 fn main() {}

--- a/tests/compile-fail/double_state_event.stderr
+++ b/tests/compile-fail/double_state_event.stderr
@@ -1,5 +1,5 @@
 error: State and event combination specified multiple times, remove duplicates.
- --> $DIR/double_state_event.rs:7:5
+ --> $DIR/double_state_event.rs:8:9
   |
-7 |     State1 + Event1 = State3, //~ State and event combination specified multiple times, remove duplicates.
-  |     ^^^^^^
+8 |         State1 + Event1 = State3, //~ State and event combination specified multiple times, remove duplicates.
+  |         ^^^^^^

--- a/tests/compile-fail/no_action_with_state_data.rs
+++ b/tests/compile-fail/no_action_with_state_data.rs
@@ -3,7 +3,9 @@ extern crate smlang;
 use smlang::statemachine;
 
 statemachine! {
-    *State1 + Event1 = State2(u32), //~ This state has data associated, but not action is define here to provide it.
+    transitions: {
+        *State1 + Event1 = State2(u32), //~ This state has data associated, but not action is define here to provide it.
+    }
 }
 
 fn main() {}

--- a/tests/compile-fail/no_action_with_state_data.stderr
+++ b/tests/compile-fail/no_action_with_state_data.stderr
@@ -1,5 +1,5 @@
 error: This state has data associated, but not action is define here to provide it.
- --> $DIR/no_action_with_state_data.rs:6:24
+ --> $DIR/no_action_with_state_data.rs:7:28
   |
-6 |     *State1 + Event1 = State2(u32), //~ This state has data associated, but not action is define here to provide it.
-  |                        ^^^^^^
+7 |         *State1 + Event1 = State2(u32), //~ This state has data associated, but not action is define here to provide it.
+  |                            ^^^^^^

--- a/tests/compile-fail/no_starting_state.rs
+++ b/tests/compile-fail/no_starting_state.rs
@@ -3,7 +3,7 @@ extern crate smlang;
 use smlang::statemachine;
 
 statemachine! { 
-    transitions {
+    transitions: {
         //~ ERROR No starting state defined, indicate the starting state with a *
         State1 + Event1 = State2,
         State2 + Event2 = State3,

--- a/tests/compile-fail/no_starting_state.rs
+++ b/tests/compile-fail/no_starting_state.rs
@@ -2,9 +2,12 @@ extern crate smlang;
 
 use smlang::statemachine;
 
-statemachine! { //~ ERROR No starting state defined, indicate the starting state with a *
-    State1 + Event1 = State2,
-    State2 + Event2 = State3,
+statemachine! { 
+    transitions {
+        //~ ERROR No starting state defined, indicate the starting state with a *
+        State1 + Event1 = State2,
+        State2 + Event2 = State3,
+    }
 }
 
 fn main() {}

--- a/tests/compile-fail/no_starting_state.stderr
+++ b/tests/compile-fail/no_starting_state.stderr
@@ -1,10 +1,13 @@
-error: expected `:`
-  --> $DIR/no_starting_state.rs:6:17
+error: No starting state defined, indicate the starting state with a *.
+  --> $DIR/no_starting_state.rs:5:1
    |
-6  |       transitions {
-   |  _________________^
+5  | / statemachine! {
+6  | |     transitions: {
 7  | |         //~ ERROR No starting state defined, indicate the starting state with a *
 8  | |         State1 + Event1 = State2,
 9  | |         State2 + Event2 = State3,
 10 | |     }
-   | |_____^
+11 | | }
+   | |_^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/no_starting_state.stderr
+++ b/tests/compile-fail/no_starting_state.stderr
@@ -1,10 +1,10 @@
-error: No starting state defined, indicate the starting state with a *.
- --> $DIR/no_starting_state.rs:5:1
-  |
-5 | / statemachine! { //~ ERROR No starting state defined, indicate the starting state with a *
-6 | |     State1 + Event1 = State2,
-7 | |     State2 + Event2 = State3,
-8 | | }
-  | |_^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+error: expected `:`
+  --> $DIR/no_starting_state.rs:6:17
+   |
+6  |       transitions {
+   |  _________________^
+7  | |         //~ ERROR No starting state defined, indicate the starting state with a *
+8  | |         State1 + Event1 = State2,
+9  | |         State2 + Event2 = State3,
+10 | |     }
+   | |_____^


### PR DESCRIPTION
- Introduce new syntax with named keywords `["transitions", "temporary_context", "guard_error"]`.
- Change signature of all guards to return `Result<(), ..>`.
- Add support for custom guard errors, with a default to `()`.

Fixes #12 

It should be straight forward for me to add some kind of naming override/prefix/postfix, now that the named syntax is introduced, in relation to #1 if you think that would be a suitable way of solving that?