### PR TITLE
Can specify initial state when creating Statemachine

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -438,7 +438,8 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
                     context
                 }
             }
-
+            
+            /// Creates a new state machine with an initial state.
             #[inline(always)]
             pub fn new_with_state(context: T, initial_state: States) -> Self {
                 StateMachine {

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -439,6 +439,14 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
                 }
             }
 
+            #[inline(always)]
+            pub fn new_with_state(context: T, initial_state: States) -> Self {
+                StateMachine {
+                    state: initial_state,
+                    context
+                }
+            }
+            
             /// Returns the current state.
             #[inline(always)]
             pub fn state(&self) -> &States {


### PR DESCRIPTION
For issue [unable to initialize statemachine with current state](https://github.com/korken89/smlang-rs/issues/19)