### PR TITLE
Validating consistent call signatures for actions and guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+* Attempts to use actions and guards with inconsistent input, event, and output state data will be
+flagged as compiler errors.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-* Attempts to use actions and guards with inconsistent input, event, and output state data will be
-flagged as compiler errors.
+* [#36](https://github.com/korken89/smlang-rs/issues/36) Attempts to use actions and guards with
+  inconsistent input, event, and output state data will be flagged as compiler errors.
 
 ### Added
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,6 +6,7 @@ mod codegen;
 #[cfg(feature = "graphviz")]
 mod diagramgen;
 mod parser;
+mod validation;
 
 use syn::parse_macro_input;
 
@@ -49,6 +50,11 @@ pub fn statemachine(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     }
                     Err(_) => panic!("'dot' failed to run. Are you sure graphviz is installed?"),
                 }
+            }
+
+            // Validate the parsed state machine before generating code.
+            if let Err(e) = validation::validate(&sm) {
+                return e.to_compile_error().into();
             }
 
             codegen::generate_code(&sm).into()

--- a/macros/src/validation.rs
+++ b/macros/src/validation.rs
@@ -1,0 +1,137 @@
+use proc_macro2::Span;
+use std::collections::HashMap;
+use syn::parse;
+
+use super::parser::ParsedStateMachine;
+
+/// A basic representation an action call signature.
+#[derive(PartialEq, Clone)]
+struct FunctionSignature {
+    // Function input arguments.
+    arguments: Vec<syn::Type>,
+
+    // Function result (if any).
+    result: Option<syn::Type>,
+}
+
+impl FunctionSignature {
+    pub fn new(
+        input_data: Option<&syn::Type>,
+        event_data: Option<&syn::Type>,
+        output_data: Option<&syn::Type>,
+    ) -> Self {
+        let mut input_arguments = vec![];
+
+        if let Some(datatype) = input_data {
+            input_arguments.push(datatype.clone());
+        }
+
+        if let Some(datatype) = event_data {
+            input_arguments.push(datatype.clone());
+        }
+
+        let result = if let Some(datatype) = output_data {
+            Some(datatype.clone())
+        } else {
+            None
+        };
+
+        Self {
+            arguments: input_arguments,
+            result,
+        }
+    }
+
+    pub fn new_guard(input_state: Option<&syn::Type>, event: Option<&syn::Type>) -> Self {
+        // Guards never have output data.
+        Self::new(input_state, event, None)
+    }
+}
+
+// Verify action and guard function signatures.
+fn validate_action_signatures(sm: &ParsedStateMachine) -> Result<(), parse::Error> {
+    // Collect all of the action call signatures.
+    let mut actions = HashMap::new();
+
+    let all_transitions = &sm.states_events_mapping;
+
+    for (in_state_name, from_transitions) in all_transitions.iter() {
+        let in_state_data = sm.state_data.data_types.get(in_state_name);
+
+        for (out_state_name, event_mapping) in from_transitions.iter() {
+            let out_state_data = sm.state_data.data_types.get(out_state_name);
+
+            // Get the data associated with this event.
+            let event_data = sm
+                .event_data
+                .data_types
+                .get(&event_mapping.event.to_string());
+
+            if let Some(action) = &event_mapping.action {
+                let signature = FunctionSignature::new(in_state_data, event_data, out_state_data);
+
+                // If the action is not yet known, add it to our tracking list.
+                if !actions.contains_key(&action.to_string()) {
+                    actions.insert(action.to_string(), signature.clone());
+                }
+
+                // Check that the call signature is equivalent to the recorded signature for this
+                // action.
+                if actions.get(&action.to_string()).unwrap() != &signature {
+                    return Err(parse::Error::new(
+                        Span::call_site(),
+                        format!("Action `{}` can only be reused when all input states, events, and output states have the same data", action),
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_guard_signatures(sm: &ParsedStateMachine) -> Result<(), parse::Error> {
+    // Collect all of the guard call signatures.
+    let mut guards = HashMap::new();
+
+    let all_transitions = &sm.states_events_mapping;
+
+    for (in_state_name, from_transitions) in all_transitions.iter() {
+        let in_state_data = sm.state_data.data_types.get(in_state_name);
+
+        for (_out_state_name, event_mapping) in from_transitions.iter() {
+            // Get the data associated with this event.
+            let event_data = sm
+                .event_data
+                .data_types
+                .get(&event_mapping.event.to_string());
+
+            if let Some(guard) = &event_mapping.guard {
+                let signature = FunctionSignature::new_guard(in_state_data, event_data);
+
+                // If the action is not yet known, add it to our tracking list.
+                if !guards.contains_key(&guard.to_string()) {
+                    guards.insert(guard.to_string(), signature.clone());
+                }
+
+                // Check that the call signature is equivalent to the recorded signature for this
+                // guard.
+                if guards.get(&guard.to_string()).unwrap() != &signature {
+                    return Err(parse::Error::new(
+                        Span::call_site(),
+                        format!("Guard `{}` can only be reused when all input states and events have the same data", guard),
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate coherency of the state machine.
+pub fn validate(sm: &ParsedStateMachine) -> Result<(), parse::Error> {
+    validate_action_signatures(sm)?;
+    validate_guard_signatures(sm)?;
+    Ok(())
+}

--- a/tests/compile-fail/duplicate_action.rs
+++ b/tests/compile-fail/duplicate_action.rs
@@ -1,0 +1,13 @@
+use smlang::statemachine;
+
+statemachine! {
+    transitions: {
+        *Init + Event / action = State1(u32),
+
+        // This transition is not valid because `action` would have different input arguments from
+        // earlier.
+        State1(u32) + Event / action = State2(u32),
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/duplicate_action.stderr
+++ b/tests/compile-fail/duplicate_action.stderr
@@ -1,0 +1,13 @@
+error: Action `action` can only be reused when all input states, events, and output states have the same data
+  --> tests/compile-fail/duplicate_action.rs:3:1
+   |
+3  | / statemachine! {
+4  | |     transitions: {
+5  | |         *Init + Event / action = State1(u32),
+6  | |
+...  |
+10 | |     }
+11 | | }
+   | |_^
+   |
+   = note: this error originates in the macro `statemachine` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/duplicate_guard.rs
+++ b/tests/compile-fail/duplicate_guard.rs
@@ -1,0 +1,13 @@
+use smlang::statemachine;
+
+statemachine! {
+    transitions: {
+        *Init + Event [guard] / action = State1(u32),
+
+        // This transition is not valid because `guard` would have different input arguments from
+        // earlier.
+        State1(u32) + Event [guard] / action2 = State2(u32),
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/duplicate_guard.stderr
+++ b/tests/compile-fail/duplicate_guard.stderr
@@ -1,0 +1,13 @@
+error: Guard `guard` can only be reused when all input states and events have the same data
+  --> tests/compile-fail/duplicate_guard.rs:3:1
+   |
+3  | / statemachine! {
+4  | |     transitions: {
+5  | |         *Init + Event [guard] / action = State1(u32),
+6  | |
+...  |
+10 | |     }
+11 | | }
+   | |_^
+   |
+   = note: this error originates in the macro `statemachine` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR fixes #36 by flagging attempts to use actions and guards with inconsistent input states, events, or output states as compiler errors to the user.

```rust
$ cat examples/reuse_action.rs
//! Reuse the same aciton more than once
//!
//! This example shows how to use the same action in multiple transitions.

#![deny(missing_docs)]

use smlang::statemachine;

statemachine! {
    transitions: {
        *Init + Startup [guard] / action = Idle(u32),
        Idle(u32) + Reset [guard] = Init,
    }
}

/// Action will increment our context
pub struct Context(u32);

impl StateMachineContext for Context {
    fn guard(&mut self) -> Result<(), ()> {
        Ok(())
    }
    fn action(&mut self) -> u32 {
        self.0
    }
}

fn main() {
    let mut sm = StateMachine::new(Context(0));
}
```
```sh
$ cargo build --example reuse_action
   Compiling smlang v0.5.0 (C:\Users\rsummers\Documents\repositories\quartiq\smlang-rs)
error: Guard `guard` can only be reused when all input states and events have the same data
  --> examples\reuse_action.rs:9:1
   |
9  | / statemachine! {
10 | |     transitions: {
11 | |         *Init + Startup [guard] / action = Idle(u32),
12 | |         Idle(u32) + Reset [guard] = Init,
13 | |     }
14 | | }
   | |_^
   |
   = note: this error originates in the macro `statemachine` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: use of undeclared type `StateMachine`
  --> examples\reuse_action.rs:29:18
   |
29 |     let mut sm = StateMachine::new(Context(0));
   |                  ^^^^^^^^^^^^ use of undeclared type `StateMachine`

error[E0405]: cannot find trait `StateMachineContext` in this scope
  --> examples\reuse_action.rs:19:6
   |
19 | impl StateMachineContext for Context {
   |      ^^^^^^^^^^^^^^^^^^^ not found in this scope

Some errors have detailed explanations: E0405, E0433.
For more information about an error, try `rustc --explain E0405`.
error: could not compile `smlang` due to 3 previous errors
```