### PR TITLE
Feature/issue 34 starting state with data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Starting state can now contain data ([issue-34](https://github.com/korken89/smlang-rs/issues/34))
+
 ## [v0.5.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ See example `examples/context.rs` for a usage example.
 
 ### State data
 
-Any state may have some data associated with it (except the starting state):
+Any state may have some data associated with it:
 
 ```rust
 pub struct MyStateData(pub u32);
@@ -107,6 +107,25 @@ statemachine!{
 ```
 
 See example `examples/state_with_data.rs` for a usage example.
+
+If the starting state contains data, this data must be provided after the context when creating a new machine.
+
+```rust
+pub struct MyStateData(pub u32);
+
+statemachine!{
+    transitions: {
+        State2 + Event2 / action = State1(MyStateData),
+        *State1(MyStateData) + Event1 = State2,
+        // ...
+    }
+    // ...
+}
+
+// ...
+
+let mut sm = StateMachine::new(Context, MyStateData(42));
+```
 
 State data may also have associated lifetimes which the `statemachine!` macro will pick up and add the `States` enum and `StateMachine` structure. This means the following will also work:
 

--- a/examples/starting_state_with_data.rs
+++ b/examples/starting_state_with_data.rs
@@ -1,0 +1,36 @@
+//! State data example
+//!
+//! An example of using state data together with an action.
+
+#![deny(missing_docs)]
+
+use smlang::statemachine;
+
+/// State data
+#[derive(PartialEq)]
+pub struct MyStateData(pub u32);
+
+statemachine! {
+    transitions: {
+        *State1(MyStateData) + Event1 = State2,
+        State2 + Event2 / action = State1,
+        // ...
+    }
+}
+
+/// Context
+pub struct Context;
+
+impl StateMachineContext for Context {
+    fn action(&mut self) -> MyStateData {
+        MyStateData(42)
+    }
+}
+
+fn main() {
+    let mut sm = StateMachine::new(Context, MyStateData(42));
+    let _ = sm.process_event(Events::Event1);
+    let result = sm.process_event(Events::Event2);
+
+    assert!(result == Ok(&States::State1(MyStateData(42))));
+}

--- a/examples/starting_state_with_data.rs
+++ b/examples/starting_state_with_data.rs
@@ -12,8 +12,8 @@ pub struct MyStateData(pub u32);
 
 statemachine! {
     transitions: {
-        *State1(MyStateData) + Event1 = State2,
         State2 + Event2 / action = State1,
+        *State1(MyStateData) + Event1 = State2,
         // ...
     }
 }

--- a/macros/src/parser/input_state.rs
+++ b/macros/src/parser/input_state.rs
@@ -38,15 +38,6 @@ impl parse::Parse for InputState {
             parenthesized!(content in input);
             let input: Type = content.parse()?;
 
-            // Check if this is the starting state, it cannot have data as there is no
-            // supported way of propagating it (for now)
-            if start {
-                return Err(parse::Error::new(
-                    input.span(),
-                    "The starting state cannot have data associated with it.",
-                ));
-            }
-
             // Wilcards should not have data associated, as data will already be defined
             if wildcard {
                 return Err(parse::Error::new(

--- a/macros/src/parser/input_state.rs
+++ b/macros/src/parser/input_state.rs
@@ -91,11 +91,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "The starting state cannot have data associated with it.")]
     fn input_state_with_data() {
-        let _: InputState = parse_quote! {
+        let state: InputState = parse_quote! {
             *Start(u8)
         };
+
+        assert!(state.start);
+        assert!(!state.wildcard);
+        assert!(state.data_type.is_some());
     }
 
     #[test]


### PR DESCRIPTION
This pull request will automatically change the signature for new() to accept state data after the context if the user specifies a starting state that contains data.  This provides a simple way of propagating it on machine instantiation.