### PR TITLE
Refactoring how guard error types are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Starting state can now contain data ([issue-34](https://github.com/korken89/smlang-rs/issues/34))
 
+### Changed
+- Custom guard error types are now specified as a type of the `StateMachineContext` to allow for
+  more versatile types.
+
 ## [v0.5.1]
 
 ### Fixed

--- a/examples/event_with_data.rs
+++ b/examples/event_with_data.rs
@@ -38,9 +38,9 @@ fn main() {
     let mut sm = StateMachine::new(Context);
     let result = sm.process_event(Events::Event1(MyEventData(1))); // Guard will fail
 
-    assert!(result == Err(Error::GuardFailed(())));
+    assert!(matches!(result, Err(Error::GuardFailed(()))));
 
     let result = sm.process_event(Events::Event1(MyEventData(42))); // Guard will pass
 
-    assert!(result == Ok(&States::State2));
+    assert!(matches!(result, Ok(&States::State2)));
 }

--- a/examples/event_with_mutable_data.rs
+++ b/examples/event_with_mutable_data.rs
@@ -36,5 +36,5 @@ fn main() {
 
     let result = sm.process_event(Events::Event1(&mut MyEventData(42))); // Guard will pass
 
-    assert!(result == Ok(&States::State2));
+    assert!(matches!(result, Ok(&States::State2)));
 }

--- a/examples/event_with_reference_data.rs
+++ b/examples/event_with_reference_data.rs
@@ -51,15 +51,15 @@ fn main() {
     let mut sm = StateMachine::new(Context);
 
     let result = sm.process_event(Events::Event1(&[])); // Guard will fail
-    assert!(result == Err(Error::GuardFailed(())));
+    assert!(matches!(result, Err(Error::GuardFailed(()))));
     let result = sm.process_event(Events::Event1(&[1, 2, 3])); // Guard will pass
-    assert!(result == Ok(&States::State2));
+    assert!(matches!(result, Ok(&States::State2)));
 
     let r = 42;
     let result = sm.process_event(Events::Event2(MyReferenceWrapper(&r))); // Guard will fail
-    assert!(result == Err(Error::GuardFailed(())));
+    assert!(matches!(result, Err(Error::GuardFailed(()))));
 
     let r = 9001;
     let result = sm.process_event(Events::Event2(MyReferenceWrapper(&r))); // Guard will pass
-    assert!(result == Ok(&States::State3));
+    assert!(matches!(result, Ok(States::State3)));
 }

--- a/examples/ex1.rs
+++ b/examples/ex1.rs
@@ -24,17 +24,17 @@ fn main() {
     assert!(sm.state() == &States::State1);
 
     let r = sm.process_event(Events::Event1);
-    assert!(r == Ok(&States::State2));
+    assert!(matches!(r, Ok(&States::State2)));
 
     let r = sm.process_event(Events::Event2);
-    assert!(r == Ok(&States::State3));
+    assert!(matches!(r, Ok(&States::State3)));
 
     // Now all events will not give any change of state
     let r = sm.process_event(Events::Event1);
-    assert!(r == Err(Error::InvalidEvent));
-    assert!(sm.state() == &States::State3);
+    assert!(matches!(r, Err(Error::InvalidEvent)));
+    assert!(matches!(sm.state(), &States::State3));
 
     let r = sm.process_event(Events::Event2);
-    assert!(r == Err(Error::InvalidEvent));
+    assert!(matches!(r, Err(Error::InvalidEvent)));
     assert!(sm.state() == &States::State3);
 }

--- a/examples/ex2.rs
+++ b/examples/ex2.rs
@@ -25,23 +25,23 @@ fn main() {
     assert!(sm.state() == &States::State1);
 
     let r = sm.process_event(Events::Event1);
-    assert!(r == Ok(&States::State2));
+    assert!(matches!(r, Ok(&States::State2)));
 
     let r = sm.process_event(Events::Event2);
-    assert!(r == Ok(&States::State3));
+    assert!(matches!(r, Ok(&States::State3)));
 
     // Go back in the loop a few time
     let r = sm.process_event(Events::Event3);
-    assert!(r == Ok(&States::State2));
+    assert!(matches!(r, Ok(&States::State2)));
 
     let r = sm.process_event(Events::Event2);
-    assert!(r == Ok(&States::State3));
+    assert!(matches!(r, Ok(&States::State3)));
 
     let r = sm.process_event(Events::Event3);
-    assert!(r == Ok(&States::State2));
+    assert!(matches!(r, Ok(&States::State2)));
 
     // Now we cannot use Event1 again, as it is outside the state machine loop
     let r = sm.process_event(Events::Event1);
-    assert!(r == Err(Error::InvalidEvent));
+    assert!(matches!(r, Err(Error::InvalidEvent)));
     assert!(sm.state() == &States::State2);
 }

--- a/examples/ex3.rs
+++ b/examples/ex3.rs
@@ -45,7 +45,7 @@ fn main() {
 
     // Go through the first guard and action
     let r = sm.process_event(Events::Event1);
-    assert!(r == Ok(&States::State2));
+    assert!(matches!(r, Ok(&States::State2)));
 
     println!("After action 1");
 
@@ -53,7 +53,7 @@ fn main() {
 
     // The action will never run as the guard will fail
     let r = sm.process_event(Events::Event2);
-    assert!(r == Err(Error::GuardFailed(())));
+    assert!(matches!(r, Err(Error::GuardFailed(()))));
 
     println!("After action 2");
 

--- a/examples/guard_custom_error.rs
+++ b/examples/guard_custom_error.rs
@@ -27,13 +27,15 @@ statemachine! {
         State2(MyStateData) + Event2  [guard2] / action2 = State3,
         // ...
     },
-    guard_error: GuardError,
+    custom_guard_error: true,
 }
 
 /// Context
 pub struct Context;
 
 impl StateMachineContext for Context {
+    type GuardError = GuardError;
+
     // Guard1 has access to the data from Event1
     fn guard1(&mut self, _event_data: &MyEventData) -> Result<(), GuardError> {
         Err(GuardError::Custom)

--- a/examples/guard_custom_error.rs
+++ b/examples/guard_custom_error.rs
@@ -57,4 +57,10 @@ impl StateMachineContext for Context {
     }
 }
 
-fn main() {}
+fn main() {
+    let mut sm = StateMachine::new(Context {});
+
+    let r = sm.process_event(Events::Event1(MyEventData(1)));
+
+    assert!(matches!(r, Err(Error::GuardFailed(GuardError::Custom))));
+}

--- a/examples/input_state_pattern_match.rs
+++ b/examples/input_state_pattern_match.rs
@@ -48,64 +48,64 @@ fn main() {
     assert!(sm.state() == &States::Idle);
 
     let r = sm.process_event(Events::Charge);
-    assert!(r == Ok(&States::Charging));
+    assert!(matches!(r, Ok(&States::Charging)));
 
     let r = sm.process_event(Events::Discharge);
-    assert!(r == Ok(&States::Discharging));
+    assert!(matches!(r, Ok(&States::Discharging)));
 
     let r = sm.process_event(Events::Charge);
-    assert!(r == Ok(&States::Charging));
+    assert!(matches!(r, Ok(&States::Charging)));
 
     let r = sm.process_event(Events::ChargeComplete);
-    assert!(r == Ok(&States::Charged));
+    assert!(matches!(r, Ok(&States::Charged)));
 
     let r = sm.process_event(Events::Charge);
-    assert!(r == Err(Error::InvalidEvent));
+    assert!(matches!(r, Err(Error::InvalidEvent)));
     assert!(sm.state() == &States::Charged);
 
     let r = sm.process_event(Events::Discharge);
-    assert!(r == Ok(&States::Discharging));
+    assert!(matches!(r, Ok(&States::Discharging)));
 
     let r = sm.process_event(Events::DischargeComplete);
-    assert!(r == Ok(&States::Discharged));
+    assert!(matches!(r, Ok(&States::Discharged)));
 
     let r = sm.process_event(Events::Discharge);
-    assert!(r == Err(Error::InvalidEvent));
+    assert!(matches!(r, Err(Error::InvalidEvent)));
     assert!(sm.state() == &States::Discharged);
 
     sm = StateMachine::new_with_state(Context, States::Idle);
     let r = sm.process_event(Events::FaultDetected);
-    assert!(r == Ok(&States::Fault));
+    assert!(matches!(r, Ok(&States::Fault)));
 
     sm = StateMachine::new_with_state(Context, States::Charging);
     let r = sm.process_event(Events::FaultDetected);
-    assert!(r == Ok(&States::Fault));
+    assert!(matches!(r, Ok(&States::Fault)));
 
     sm = StateMachine::new_with_state(Context, States::Charged);
     let r = sm.process_event(Events::FaultDetected);
-    assert!(r == Ok(&States::Fault));
+    assert!(matches!(r, Ok(&States::Fault)));
 
     sm = StateMachine::new_with_state(Context, States::Discharging);
     let r = sm.process_event(Events::FaultDetected);
-    assert!(r == Ok(&States::Fault));
+    assert!(matches!(r, Ok(&States::Fault)));
 
     sm = StateMachine::new_with_state(Context, States::Discharged);
     let r = sm.process_event(Events::FaultDetected);
-    assert!(r == Ok(&States::Fault));
+    assert!(matches!(r, Ok(&States::Fault)));
 
     let r = sm.process_event(Events::Charge);
-    assert!(r == Err(Error::InvalidEvent));
+    assert!(matches!(r, Err(Error::InvalidEvent)));
     assert!(sm.state() == &States::Fault);
 
     let r = sm.process_event(Events::Discharge);
-    assert!(r == Err(Error::InvalidEvent));
+    assert!(matches!(r, Err(Error::InvalidEvent)));
     assert!(sm.state() == &States::Fault);
 
     let r = sm.process_event(Events::ChargeComplete);
-    assert!(r == Err(Error::InvalidEvent));
+    assert!(matches!(r, Err(Error::InvalidEvent)));
     assert!(sm.state() == &States::Fault);
 
     let r = sm.process_event(Events::DischargeComplete);
-    assert!(r == Err(Error::InvalidEvent));
+    assert!(matches!(r, Err(Error::InvalidEvent)));
     assert!(sm.state() == &States::Fault);
 }

--- a/examples/reuse_action.rs
+++ b/examples/reuse_action.rs
@@ -30,15 +30,15 @@ fn main() {
 
     // triggers action
     let r = sm.process_event(Events::Event1);
-    assert!(r == Ok(&States::State2));
+    assert!(matches!(r, Ok(&States::State2)));
     assert!(sm.context.0 == 1);
 
     let r = sm.process_event(Events::Event2);
-    assert!(r == Ok(&States::State1));
+    assert!(matches!(r, Ok(&States::State1)));
     assert!(sm.context.0 == 1);
 
     // triggers the same action
     let r = sm.process_event(Events::Event2);
-    assert!(r == Ok(&States::State3));
+    assert!(matches!(r, Ok(&States::State3)));
     assert!(sm.context.0 == 2);
 }

--- a/examples/starting_state_with_data.rs
+++ b/examples/starting_state_with_data.rs
@@ -32,5 +32,5 @@ fn main() {
     let _ = sm.process_event(Events::Event1);
     let result = sm.process_event(Events::Event2);
 
-    assert!(result == Ok(&States::State1(MyStateData(42))));
+    assert!(matches!(result, Ok(&States::State1(MyStateData(42)))));
 }

--- a/examples/state_with_data.rs
+++ b/examples/state_with_data.rs
@@ -31,5 +31,5 @@ fn main() {
     let mut sm = StateMachine::new(Context);
     let result = sm.process_event(Events::Event1);
 
-    assert!(result == Ok(&States::State2(MyStateData(42))));
+    assert!(matches!(result, Ok(&States::State2(MyStateData(42)))));
 }

--- a/examples/state_with_reference_data.rs
+++ b/examples/state_with_reference_data.rs
@@ -31,5 +31,5 @@ fn main() {
     let mut sm = StateMachine::new(Context);
     let result = sm.process_event(Events::Event1);
 
-    assert!(result == Ok(&States::State2(MyStateData(&42))));
+    assert!(matches!(result, Ok(&States::State2(MyStateData(&42)))));
 }

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -440,7 +440,6 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
         quote! {Error}
     };
 
-
     // Build the states and events output
     quote! {
         /// This trait outlines the guards and actions that need to be implemented for the state

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -248,8 +248,8 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
                     }
                 };
 
-                let guard_error = if let Some(ref guard_error) = sm.guard_error {
-                    quote! { #guard_error }
+                let guard_error = if sm.custom_guard_error {
+                    quote! { Self::GuardError }
 
                 } else {
                     quote! { () }
@@ -355,26 +355,14 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
                         if let Some(g) = guard {
                             if let Some(a) = action {
                                 quote! {
-                                    match self.context.#g(#temporary_context_call #g_a_param) {
-                                        Ok(()) => {
-                                            let _data = self.context.#a(#temporary_context_call #g_a_param);
-                                            self.state = States::#out_state;
-                                        },
-                                        Err(e) => {
-                                            return Err(Error::GuardFailed(e));
-                                        }
-                                    }
+                                    self.context.#g(#temporary_context_call #g_a_param).map_err(Error::GuardFailed)?;
+                                    let _data = self.context.#a(#temporary_context_call #g_a_param);
+                                    self.state = States::#out_state;
                                 }
                             } else {
                                 quote! {
-                                    match self.context.#g(#temporary_context_call #g_a_param) {
-                                        Ok(()) => {
-                                            self.state = States::#out_state;
-                                        },
-                                        Err(e) => {
-                                            return Err(Error::GuardFailed(e));
-                                        }
-                                    }
+                                    self.context.#g(#temporary_context_call #g_a_param).map_err(Error::GuardFailed)?;
+                                    self.state = States::#out_state;
                                 }
                             }
                         } else {
@@ -435,17 +423,30 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
         quote! {#(#event_lifetimes),* ,}
     };
 
-    let guard_failed = if let Some(ref guard_error) = sm.guard_error {
-        quote! { GuardFailed(#guard_error) }
+    let guard_error = if sm.custom_guard_error {
+        quote! {
+            /// The error type returned by guard functions.
+            type GuardError;
+        }
     } else {
-        quote! { GuardFailed(()) }
+        quote! {}
     };
+
+    let error_type = if sm.custom_guard_error {
+        quote! {
+            Error<<T as StateMachineContext>::GuardError>
+        }
+    } else {
+        quote! {Error}
+    };
+
 
     // Build the states and events output
     quote! {
         /// This trait outlines the guards and actions that need to be implemented for the state
         /// machine.
         pub trait StateMachineContext {
+            #guard_error
             #guard_list
             #action_list
         }
@@ -475,12 +476,12 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
         }
 
         /// List of possible errors
-        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        pub enum Error {
+        #[derive(Debug)]
+        pub enum Error<T=()> {
             /// When an event is processed which should not come in the current state.
             InvalidEvent,
             /// When an event is processed whose guard did not return `true`.
-            #guard_failed,
+            GuardFailed(T),
         }
 
         /// State machine structure definition.
@@ -525,7 +526,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
             ///
             /// It will return `Ok(&NextState)` if the transition was successful, or `Err(Error)`
             /// if there was an error in the transition.
-            pub fn process_event(&mut self, #temporary_context mut event: Events) -> Result<&States, Error> {
+            pub fn process_event(&mut self, #temporary_context mut event: Events) -> Result<&States, #error_type> {
                 match self.state {
                     #(States::#in_states => match event {
                         #(Events::#events => {

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -426,7 +426,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
     let guard_error = if sm.custom_guard_error {
         quote! {
             /// The error type returned by guard functions.
-            type GuardError;
+            type GuardError: core::fmt::Debug;
         }
     } else {
         quote! {}

--- a/macros/src/parser/mod.rs
+++ b/macros/src/parser/mod.rs
@@ -21,7 +21,7 @@ pub type TransitionMap = HashMap<String, HashMap<String, EventMapping>>;
 #[derive(Debug)]
 pub struct ParsedStateMachine {
     pub temporary_context_type: Option<Type>,
-    pub guard_error: Option<Type>,
+    pub custom_guard_error: bool,
     pub states: HashMap<String, Ident>,
     pub starting_state: Ident,
     pub state_data: DataDefinitions,
@@ -178,7 +178,7 @@ impl ParsedStateMachine {
 
         Ok(ParsedStateMachine {
             temporary_context_type: sm.temporary_context_type,
-            guard_error: sm.guard_error,
+            custom_guard_error: sm.custom_guard_error,
             states,
             starting_state,
             state_data,


### PR DESCRIPTION
This PR refactors how custom guard errors are specified.

Instead of specifying the custom type in the `statemachine!` macro, the guard error is specified as an associated-type of the trait object.

This makes guard errors more usable for cases when the concrete type of the error is unknown at the declaration of the statemachine (e.g. errors with generic parameters).

I've also removed the `derive(Copy, Clone, Eq, PartialEq)` for `enum Error`. There are many types of `GuardErrors` that would not necessarily implement all of these traits. Since the user is still able to manually implement these traits outside of the declaration, it seems better to be less strict about what types of `GuardError` are acceptable.