### PR TITLE
Allow input states before wildcard state for the same event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Starting state can now contain data ([issue-34](https://github.com/korken89/smlang-rs/issues/34))
+- Allow explicit input states before wildcard input state([issue-47](https://github.com/korken89/smlang-rs/pull/47)
 
 ## [v0.5.1]
 

--- a/tests/compile-fail/wildcard_before_input_state.rs
+++ b/tests/compile-fail/wildcard_before_input_state.rs
@@ -1,0 +1,12 @@
+extern crate smlang;
+
+use smlang::statemachine;
+
+statemachine! {
+    transitions: {
+        _ + Event1 = Fault, //~ State and event combination specified multiple times, remove duplicates.
+        *State1 + Event1 = State2,
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/wildcard_before_input_state.stderr
+++ b/tests/compile-fail/wildcard_before_input_state.stderr
@@ -1,0 +1,5 @@
+error: State and event combination specified multiple times, remove duplicates.
+ --> tests/compile-fail/wildcard_before_input_state.rs:8:10
+  |
+8 |         *State1 + Event1 = State2,
+  |          ^^^^^^

--- a/tests/compile-fail/wildcard_no_effect.rs
+++ b/tests/compile-fail/wildcard_no_effect.rs
@@ -1,0 +1,13 @@
+extern crate smlang;
+
+use smlang::statemachine;
+
+statemachine! {
+    transitions: {
+        *State1 + Event1 = State2,
+        _ + Event1 = Fault,
+        _ + Event1 = State3, //~ Wildcard has no effect
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/wildcard_no_effect.stderr
+++ b/tests/compile-fail/wildcard_no_effect.stderr
@@ -1,0 +1,5 @@
+error: Wildcard has no effect
+ --> tests/compile-fail/wildcard_no_effect.rs:9:9
+  |
+9 |         _ + Event1 = State3, //~ Wildcard has no effect
+  |         ^

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,30 @@
+extern crate smlang;
+
+use smlang::statemachine;
+
 #[test]
-fn tests() {
+fn compile_fail_tests() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile-fail/*.rs");
+}
+
+#[test]
+fn wildcard_after_input_state() {
+    statemachine! {
+        transitions: {
+            *State1 + Event1 = State2,
+            _ + Event1 = Fault,
+        }
+    }
+
+    struct Context;
+    impl StateMachineContext for Context {}
+
+    let mut sm = StateMachine::new(Context);
+
+    sm.process_event(Events::Event1).unwrap();
+    assert!(sm.state() == &States::State2);
+
+    sm.process_event(Events::Event1).unwrap();
+    assert!(sm.state() == &States::Fault);
 }


### PR DESCRIPTION
This allows the following:

```rust
statemachine!{
    transitions: {
        *State1 + Event1 = State2,
        _ + Event1 = Fault,
    }
}
```