### PR TITLE
Make `StateMachine::new` and `StateMachine::new_with_state` const functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- `StateMachine::new` and `StateMachine::new_with_state` are now const functions
 
 ## [v0.6.0] - 2022-11-02
 

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -390,7 +390,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
     let starting_state_name = starting_state.to_string();
     let new_sm_code = match sm.state_data.data_types.get(&starting_state_name) {
         Some(st) => quote! {
-            pub fn new(context: T, state_data: #st ) -> Self {
+            pub const fn new(context: T, state_data: #st ) -> Self {
                 StateMachine {
                     state: States::#starting_state (state_data),
                     context
@@ -398,7 +398,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
             }
         },
         None => quote! {
-            pub fn new(context: T ) -> Self {
+            pub const fn new(context: T ) -> Self {
                 StateMachine {
                     state: States::#starting_state,
                     context
@@ -496,7 +496,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
 
             /// Creates a new state machine with an initial state.
             #[inline(always)]
-            pub fn new_with_state(context: T, initial_state: States <#state_lifetimes_code>) -> Self {
+            pub const fn new_with_state(context: T, initial_state: States <#state_lifetimes_code>) -> Self {
                 StateMachine {
                     state: initial_state,
                     context


### PR DESCRIPTION
`StateMachine::new` and `StateMachine::new_with_state`  are just filling the struct without calling any function, so they can became const functions to ease construction.

Closes #45