### PR TITLE
Fix clippy warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,28 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all -- -D warnings
+
   # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   #
   # ALL THE PREVIOUS JOBS NEEDS TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
@@ -81,6 +103,7 @@ jobs:
       - check
       - test
       - fmt
+      - clippy
     runs-on: ubuntu-latest
     steps:
       - name: Mark the job as a success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [breaking] Actions now take owned values
 - [breaking] `state()` now returns a `Result`
 - `StateMachine::new` and `StateMachine::new_with_state` are now const functions
+- Fixed clippy warnings
 
 ## [v0.6.0] - 2022-11-02
 

--- a/macros/src/parser/state_machine.rs
+++ b/macros/src/parser/state_machine.rs
@@ -60,7 +60,7 @@ impl parse::Parse for StateMachine {
                                 break;
                             }
 
-                            if let Err(_) = content.parse::<Token![,]>() {
+                            if content.parse::<Token![,]>().is_err() {
                                 break;
                             };
                         }
@@ -111,7 +111,7 @@ impl parse::Parse for StateMachine {
                 break;
             }
 
-            if let Err(_) = input.parse::<Token![,]>() {
+            if input.parse::<Token![,]>().is_err() {
                 break;
             };
         }

--- a/macros/src/parser/transition.rs
+++ b/macros/src/parser/transition.rs
@@ -28,7 +28,7 @@ impl parse::Parse for StateTransitions {
         loop {
             let in_state: InputState = input.parse()?;
             in_states.push(in_state);
-            if let Err(_) = input.parse::<Token![|]>() {
+            if input.parse::<Token![|]>().is_err() {
                 break;
             };
         }
@@ -59,7 +59,7 @@ impl parse::Parse for StateTransitions {
         };
 
         // Possible action
-        let action = if let Ok(_) = input.parse::<Token![/]>() {
+        let action = if input.parse::<Token![/]>().is_ok() {
             let action: Ident = input.parse()?;
             Some(action)
         } else {

--- a/macros/src/validation.rs
+++ b/macros/src/validation.rs
@@ -30,11 +30,7 @@ impl FunctionSignature {
             input_arguments.push(datatype.clone());
         }
 
-        let result = if let Some(datatype) = output_data {
-            Some(datatype.clone())
-        } else {
-            None
-        };
+        let result = output_data.cloned();
 
         Self {
             arguments: input_arguments,
@@ -71,9 +67,9 @@ fn validate_action_signatures(sm: &ParsedStateMachine) -> Result<(), parse::Erro
                 let signature = FunctionSignature::new(in_state_data, event_data, out_state_data);
 
                 // If the action is not yet known, add it to our tracking list.
-                if !actions.contains_key(&action.to_string()) {
-                    actions.insert(action.to_string(), signature.clone());
-                }
+                actions
+                    .entry(action.to_string())
+                    .or_insert_with(|| signature.clone());
 
                 // Check that the call signature is equivalent to the recorded signature for this
                 // action.
@@ -110,9 +106,9 @@ fn validate_guard_signatures(sm: &ParsedStateMachine) -> Result<(), parse::Error
                 let signature = FunctionSignature::new_guard(in_state_data, event_data);
 
                 // If the action is not yet known, add it to our tracking list.
-                if !guards.contains_key(&guard.to_string()) {
-                    guards.insert(guard.to_string(), signature.clone());
-                }
+                guards
+                    .entry(guard.to_string())
+                    .or_insert_with(|| signature.clone());
 
                 // Check that the call signature is equivalent to the recorded signature for this
                 // guard.

--- a/tests/compile-fail/multiple_starting_state.rs
+++ b/tests/compile-fail/multiple_starting_state.rs
@@ -1,0 +1,13 @@
+extern crate smlang;
+
+use smlang::statemachine;
+
+statemachine! {
+    transitions: {
+        //~ More than one starting state defined (indicated with *), remove duplicates.
+        *State1 + Event1 = State2,
+        *State2 + Event2 = State3,
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/multiple_starting_state.stderr
+++ b/tests/compile-fail/multiple_starting_state.stderr
@@ -1,0 +1,13 @@
+error: More than one starting state defined (indicated with *), remove duplicates.
+  --> tests/compile-fail/multiple_starting_state.rs:5:1
+   |
+5  | / statemachine! {
+6  | |     transitions: {
+7  | |         //~ More than one starting state defined (indicated with *), remove duplicates.
+8  | |         *State1 + Event1 = State2,
+9  | |         *State2 + Event2 = State3,
+10 | |     }
+11 | | }
+   | |_^
+   |
+   = note: this error originates in the macro `statemachine` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This fixes clippy warnings and adds clippy in CI. I also added a missing test case.

There is a small caveat by having clippy in CI: When someone opens a PR, their CI pipeline may fail in places they never touched. This is because newer versions of clippy have for more lints.