### PR TITLE
Add support for async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add `impl_display_{states,events}` for auto-impementation of `core::fmt::Display` on `States` and/or `Events`
+- Add support for async guards and actions
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ readme = "README.md"
 [dependencies]
 smlang-macros = { path = "macros", version = "0.6.0" }
 
+[dev-dependencies]
+smol = "1"
+async-trait = "0.1.68"
+
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
 trybuild = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 
 [dependencies]
 smlang-macros = { path = "macros", version = "0.6.0" }
+async-trait = "0.1"
 
 [dev-dependencies]
 smol = "1"
-async-trait = "0.1.68"
 
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
 trybuild = "1.0"

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ See example `examples/event_with_data.rs` for a usage example.
 
 See example `examples/guard_action_syntax.rs` for a usage-example.
 
+### Async Guard and Action
+
+See example `examples/async.rs` for a usage-example.
+
 ## State Machine Examples
 
 Here are some examples of state machines converted from UML to the State Machine Language DSL. Runnable versions of each example is available in the `examples` folder.

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,0 +1,85 @@
+//! Async guards and actions example
+//!
+//! An example of using async guards and actions mixed with standard ones.
+
+#![deny(missing_docs)]
+
+use smlang::statemachine;
+use smol;
+use async_trait::async_trait;
+
+statemachine! {
+    is_async: true,
+    transitions: {
+        *State1 + Event1 [guard1] / async action1 = State2,
+        State2 + Event2 [async guard2] / async action2 = State3,
+        State3 + Event3 / action3 = State4(bool),
+    }
+}
+
+/// Context with member
+pub struct Context {
+    lock: smol::lock::RwLock<bool>,
+    done: bool,
+}
+
+#[async_trait]
+impl StateMachineContext for Context {
+    fn guard1(&mut self) -> Result<(),()>  {
+        println!("`guard1` called from sync context");
+        Ok(())
+    }
+
+    async fn action1(&mut self) ->  () {
+        println!("`action1` called from async context");
+        let mut lock = self.lock.write().await;
+        *lock = true;
+    }
+
+    async fn guard2(&mut self) ->  Result<(),()> {
+        println!("`guard2` called from async context");
+        let mut lock = self.lock.write().await;
+        *lock = false;
+        Ok(())
+    }
+
+    async fn action2(&mut self) -> () {
+        println!("`action2` called from async context");
+        if ! *self.lock.read().await {
+            self.done = true;
+        }
+    }
+
+    fn action3(&mut self) -> bool {
+        println!("`action3` called from sync context, done = `{}`", self.done);
+        self.done
+    }
+}
+
+fn main() {
+    smol::block_on(async {
+        let mut sm = StateMachine::new(Context {lock: smol::lock::RwLock::new(false), done: false});
+        assert!(matches!(sm.state(), Ok(&States::State1)));
+
+        let r = sm.process_event(Events::Event1).await;
+        assert!(matches!(r, Ok(&States::State2)));
+
+        let r = sm.process_event(Events::Event2).await;
+        assert!(matches!(r, Ok(&States::State3)));
+
+        let r = sm.process_event(Events::Event3).await;
+        assert!(matches!(r, Ok(&States::State4(true))));
+
+        // Now all events will not give any change of state
+        let r = sm.process_event(Events::Event1).await;
+        assert!(matches!(r, Err(Error::InvalidEvent)));
+        assert!(matches!(sm.state(), Ok(&States::State4(_))));
+
+        let r = sm.process_event(Events::Event2).await;
+        assert!(matches!(r, Err(Error::InvalidEvent)));
+        assert!(matches!(sm.state(), Ok(&States::State4(_))));
+    });
+
+
+    // ...
+}

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -4,9 +4,9 @@
 
 #![deny(missing_docs)]
 
+use async_trait::async_trait;
 use smlang::statemachine;
 use smol;
-use async_trait::async_trait;
 
 statemachine! {
     is_async: true,
@@ -25,18 +25,18 @@ pub struct Context {
 
 #[async_trait]
 impl StateMachineContext for Context {
-    fn guard1(&mut self) -> Result<(),()>  {
+    fn guard1(&mut self) -> Result<(), ()> {
         println!("`guard1` called from sync context");
         Ok(())
     }
 
-    async fn action1(&mut self) ->  () {
+    async fn action1(&mut self) -> () {
         println!("`action1` called from async context");
         let mut lock = self.lock.write().await;
         *lock = true;
     }
 
-    async fn guard2(&mut self) ->  Result<(),()> {
+    async fn guard2(&mut self) -> Result<(), ()> {
         println!("`guard2` called from async context");
         let mut lock = self.lock.write().await;
         *lock = false;
@@ -45,7 +45,7 @@ impl StateMachineContext for Context {
 
     async fn action2(&mut self) -> () {
         println!("`action2` called from async context");
-        if ! *self.lock.read().await {
+        if !*self.lock.read().await {
             self.done = true;
         }
     }
@@ -58,7 +58,10 @@ impl StateMachineContext for Context {
 
 fn main() {
     smol::block_on(async {
-        let mut sm = StateMachine::new(Context {lock: smol::lock::RwLock::new(false), done: false});
+        let mut sm = StateMachine::new(Context {
+            lock: smol::lock::RwLock::new(false),
+            done: false,
+        });
         assert!(matches!(sm.state(), Ok(&States::State1)));
 
         let r = sm.process_event(Events::Event1).await;
@@ -79,7 +82,6 @@ fn main() {
         assert!(matches!(r, Err(Error::InvalidEvent)));
         assert!(matches!(sm.state(), Ok(&States::State4(_))));
     });
-
 
     // ...
 }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -9,7 +9,6 @@ use smlang::statemachine;
 use smol;
 
 statemachine! {
-    is_async: true,
     transitions: {
         *State1 + Event1 [guard1] / async action1 = State2,
         State2 + Event2 [async guard2] / async action2 = State3,

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -4,8 +4,7 @@
 
 #![deny(missing_docs)]
 
-use async_trait::async_trait;
-use smlang::statemachine;
+use smlang::{async_trait, statemachine};
 use smol;
 
 statemachine! {

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -477,7 +477,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
     };
 
     let (is_async, is_async_trait) = if sm_is_async {
-        (quote! { async }, quote! { #[async_trait::async_trait] })
+        (quote! { async }, quote! { #[smlang::async_trait] })
     } else {
         (quote! {}, quote! {})
     };

--- a/macros/src/parser/event.rs
+++ b/macros/src/parser/event.rs
@@ -10,8 +10,8 @@ pub struct Event {
 pub struct EventMapping {
     pub in_state: Ident,
     pub event: Ident,
-    pub guard: Option<Ident>,
-    pub action: Option<Ident>,
+    pub guard: Option<(Ident, bool)>,
+    pub action: Option<(Ident, bool)>,
     pub out_state: Ident,
 }
 

--- a/macros/src/parser/event.rs
+++ b/macros/src/parser/event.rs
@@ -1,3 +1,4 @@
+use crate::parser::AsyncIdent;
 use syn::{parenthesized, parse, spanned::Spanned, token, Ident, Token, Type};
 
 #[derive(Debug, Clone)]
@@ -10,8 +11,8 @@ pub struct Event {
 pub struct EventMapping {
     pub in_state: Ident,
     pub event: Ident,
-    pub guard: Option<(Ident, bool)>,
-    pub action: Option<(Ident, bool)>,
+    pub guard: Option<AsyncIdent>,
+    pub action: Option<AsyncIdent>,
     pub out_state: Ident,
 }
 

--- a/macros/src/parser/mod.rs
+++ b/macros/src/parser/mod.rs
@@ -31,7 +31,6 @@ pub struct ParsedStateMachine {
     pub custom_guard_error: bool,
     pub impl_display_events: bool,
     pub impl_display_states: bool,
-    pub is_async: bool,
     pub states: HashMap<String, Ident>,
     pub starting_state: Ident,
     pub state_data: DataDefinitions,
@@ -200,7 +199,6 @@ impl ParsedStateMachine {
         Ok(ParsedStateMachine {
             temporary_context_type: sm.temporary_context_type,
             custom_guard_error: sm.custom_guard_error,
-            is_async: sm.is_async,
             states,
             starting_state,
             state_data,

--- a/macros/src/parser/mod.rs
+++ b/macros/src/parser/mod.rs
@@ -19,6 +19,12 @@ use transition::StateTransition;
 
 pub type TransitionMap = HashMap<String, HashMap<String, EventMapping>>;
 
+#[derive(Debug, Clone)]
+pub struct AsyncIdent {
+    pub ident: Ident,
+    pub is_async: bool,
+}
+
 #[derive(Debug)]
 pub struct ParsedStateMachine {
     pub temporary_context_type: Option<Type>,

--- a/macros/src/parser/mod.rs
+++ b/macros/src/parser/mod.rs
@@ -25,6 +25,7 @@ pub struct ParsedStateMachine {
     pub custom_guard_error: bool,
     pub impl_display_events: bool,
     pub impl_display_states: bool,
+    pub is_async: bool,
     pub states: HashMap<String, Ident>,
     pub starting_state: Ident,
     pub state_data: DataDefinitions,
@@ -193,6 +194,7 @@ impl ParsedStateMachine {
         Ok(ParsedStateMachine {
             temporary_context_type: sm.temporary_context_type,
             custom_guard_error: sm.custom_guard_error,
+            is_async: sm.is_async,
             states,
             starting_state,
             state_data,

--- a/macros/src/parser/state_machine.rs
+++ b/macros/src/parser/state_machine.rs
@@ -7,7 +7,6 @@ pub struct StateMachine {
     pub custom_guard_error: bool,
     pub impl_display_states: bool,
     pub impl_display_events: bool,
-    pub is_async: bool,
     pub transitions: Vec<StateTransition>,
 }
 
@@ -18,7 +17,6 @@ impl StateMachine {
             custom_guard_error: false,
             impl_display_states: false,
             impl_display_events: false,
-            is_async: false,
             transitions: Vec::new(),
         }
     }
@@ -92,13 +90,6 @@ impl parse::Parse for StateMachine {
                     let b: syn::LitBool = input.parse()?;
                     if b.value {
                         statemachine.impl_display_events = true
-                    }
-                }
-                "is_async" => {
-                    input.parse::<Token![:]>()?;
-                    let is_async: syn::LitBool = input.parse()?;
-                    if is_async.value {
-                        statemachine.is_async = true
                     }
                 }
                 "temporary_context" => {

--- a/macros/src/parser/state_machine.rs
+++ b/macros/src/parser/state_machine.rs
@@ -7,6 +7,7 @@ pub struct StateMachine {
     pub custom_guard_error: bool,
     pub impl_display_states: bool,
     pub impl_display_events: bool,
+    pub is_async: bool,
     pub transitions: Vec<StateTransition>,
 }
 
@@ -17,6 +18,7 @@ impl StateMachine {
             custom_guard_error: false,
             impl_display_states: false,
             impl_display_events: false,
+            is_async: false,
             transitions: Vec::new(),
         }
     }
@@ -90,6 +92,13 @@ impl parse::Parse for StateMachine {
                     let b: syn::LitBool = input.parse()?;
                     if b.value {
                         statemachine.impl_display_events = true
+                    }
+                }
+                "is_async" => {
+                    input.parse::<Token![:]>()?;
+                    let is_async: syn::LitBool = input.parse()?;
+                    if is_async.value {
+                        statemachine.is_async = true
                     }
                 }
                 "temporary_context" => {

--- a/macros/src/parser/transition.rs
+++ b/macros/src/parser/transition.rs
@@ -7,8 +7,8 @@ use syn::{bracketed, parse, token, Ident, Token};
 pub struct StateTransition {
     pub in_state: InputState,
     pub event: Event,
-    pub guard: Option<Ident>,
-    pub action: Option<Ident>,
+    pub guard: Option<(Ident, bool)>,
+    pub action: Option<(Ident, bool)>,
     pub out_state: OutputState,
 }
 
@@ -16,8 +16,8 @@ pub struct StateTransition {
 pub struct StateTransitions {
     pub in_states: Vec<InputState>,
     pub event: Event,
-    pub guard: Option<Ident>,
-    pub action: Option<Ident>,
+    pub guard: Option<(Ident, bool)>,
+    pub action: Option<(Ident, bool)>,
     pub out_state: OutputState,
 }
 
@@ -52,16 +52,18 @@ impl parse::Parse for StateTransitions {
         let guard = if input.peek(token::Bracket) {
             let content;
             bracketed!(content in input);
+            let is_async = content.parse::<token::Async>().is_ok();
             let guard: Ident = content.parse()?;
-            Some(guard)
+            Some((guard, is_async))
         } else {
             None
         };
 
         // Possible action
         let action = if input.parse::<Token![/]>().is_ok() {
+            let is_async = input.parse::<token::Async>().is_ok();
             let action: Ident = input.parse()?;
-            Some(action)
+            Some((action, is_async))
         } else {
             None
         };

--- a/macros/src/parser/transition.rs
+++ b/macros/src/parser/transition.rs
@@ -1,14 +1,15 @@
 use super::event::Event;
 use super::input_state::InputState;
 use super::output_state::OutputState;
+use super::AsyncIdent;
 use syn::{bracketed, parse, token, Ident, Token};
 
 #[derive(Debug)]
 pub struct StateTransition {
     pub in_state: InputState,
     pub event: Event,
-    pub guard: Option<(Ident, bool)>,
-    pub action: Option<(Ident, bool)>,
+    pub guard: Option<AsyncIdent>,
+    pub action: Option<AsyncIdent>,
     pub out_state: OutputState,
 }
 
@@ -16,8 +17,8 @@ pub struct StateTransition {
 pub struct StateTransitions {
     pub in_states: Vec<InputState>,
     pub event: Event,
-    pub guard: Option<(Ident, bool)>,
-    pub action: Option<(Ident, bool)>,
+    pub guard: Option<AsyncIdent>,
+    pub action: Option<AsyncIdent>,
     pub out_state: OutputState,
 }
 
@@ -54,7 +55,10 @@ impl parse::Parse for StateTransitions {
             bracketed!(content in input);
             let is_async = content.parse::<token::Async>().is_ok();
             let guard: Ident = content.parse()?;
-            Some((guard, is_async))
+            Some(AsyncIdent {
+                ident: guard,
+                is_async,
+            })
         } else {
             None
         };
@@ -63,7 +67,10 @@ impl parse::Parse for StateTransitions {
         let action = if input.parse::<Token![/]>().is_ok() {
             let is_async = input.parse::<token::Async>().is_ok();
             let action: Ident = input.parse()?;
-            Some((action, is_async))
+            Some(AsyncIdent {
+                ident: action,
+                is_async,
+            })
         } else {
             None
         };

--- a/macros/src/validation.rs
+++ b/macros/src/validation.rs
@@ -1,8 +1,7 @@
+use crate::parser::{AsyncIdent, ParsedStateMachine};
 use proc_macro2::Span;
 use std::collections::HashMap;
 use syn::parse;
-
-use super::parser::ParsedStateMachine;
 
 /// A basic representation an action call signature.
 #[derive(PartialEq, Clone)]
@@ -72,7 +71,11 @@ fn validate_action_signatures(sm: &ParsedStateMachine) -> Result<(), parse::Erro
                 .data_types
                 .get(&event_mapping.event.to_string());
 
-            if let Some((action, is_async)) = &event_mapping.action {
+            if let Some(AsyncIdent {
+                ident: action,
+                is_async,
+            }) = &event_mapping.action
+            {
                 let signature =
                     FunctionSignature::new(in_state_data, event_data, out_state_data, *is_async);
 
@@ -112,7 +115,11 @@ fn validate_guard_signatures(sm: &ParsedStateMachine) -> Result<(), parse::Error
                 .data_types
                 .get(&event_mapping.event.to_string());
 
-            if let Some((guard, is_async)) = &event_mapping.guard {
+            if let Some(AsyncIdent {
+                ident: guard,
+                is_async,
+            }) = &event_mapping.guard
+            {
                 let signature = FunctionSignature::new_guard(in_state_data, event_data, *is_async);
 
                 // If the action is not yet known, add it to our tracking list.

--- a/macros/src/validation.rs
+++ b/macros/src/validation.rs
@@ -43,7 +43,11 @@ impl FunctionSignature {
         }
     }
 
-    pub fn new_guard(input_state: Option<&syn::Type>, event: Option<&syn::Type>, is_async: bool) -> Self {
+    pub fn new_guard(
+        input_state: Option<&syn::Type>,
+        event: Option<&syn::Type>,
+        is_async: bool,
+    ) -> Self {
         // Guards never have output data.
         Self::new(input_state, event, None, is_async)
     }
@@ -69,7 +73,8 @@ fn validate_action_signatures(sm: &ParsedStateMachine) -> Result<(), parse::Erro
                 .get(&event_mapping.event.to_string());
 
             if let Some((action, is_async)) = &event_mapping.action {
-                let signature = FunctionSignature::new(in_state_data, event_data, out_state_data, *is_async);
+                let signature =
+                    FunctionSignature::new(in_state_data, event_data, out_state_data, *is_async);
 
                 // If the action is not yet known, add it to our tracking list.
                 actions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,4 +66,5 @@
 
 #![no_std]
 
+pub use async_trait::async_trait;
 pub use smlang_macros::statemachine;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -118,7 +118,7 @@ fn async_guards_and_actions() {
         struct Context;
         #[async_trait]
         impl StateMachineContext for Context {
-            async fn guard1(&mut self) -> Result<(),()>  {
+            async fn guard1(&mut self) -> Result<(), ()> {
                 Ok(())
             }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -102,7 +102,6 @@ fn impl_display_events_states() {
 
 #[test]
 fn async_guards_and_actions() {
-    use async_trait::async_trait;
     use smol;
 
     smol::block_on(async {
@@ -114,7 +113,7 @@ fn async_guards_and_actions() {
         }
 
         struct Context;
-        #[async_trait]
+        #[smlang::async_trait]
         impl StateMachineContext for Context {
             async fn guard1(&mut self) -> Result<(), ()> {
                 Ok(())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -100,7 +100,6 @@ fn impl_display_events_states() {
     assert_eq!(format!("{}", sm.state().unwrap()), "End");
 }
 
-
 #[test]
 fn async_guards_and_actions() {
     use async_trait::async_trait;
@@ -108,7 +107,6 @@ fn async_guards_and_actions() {
 
     smol::block_on(async {
         statemachine! {
-            is_async: true,
             transitions: {
                 *State1 + Event1 [async guard1] / async action1 = State2,
                 _ + Event1 = Fault,


### PR DESCRIPTION
This PR allows to use async guards and actions for an easier integration with existing async code.
See example in [examples/async.rs](https://github.com/yaak-ai/smlang-rs/blob/f1639a4f9840d04c9c19dfda1c3b1d5b07b91f1a/examples/async.rs) for usage.