### PR TITLE
Feature: Add macro flags for derive(Debug).

### DIFF
--- a/examples/impl_display_and_debug.rs
+++ b/examples/impl_display_and_debug.rs
@@ -1,0 +1,52 @@
+//! Display and Debug example
+//!
+//! An example showing the usage of impl_display_* and impl_debug_*.
+
+#![deny(missing_docs)]
+
+use smlang::statemachine;
+
+statemachine! {
+    impl_debug_events: true,
+    impl_debug_states: true,
+    impl_display_events: true,
+    impl_display_states: true,
+    impl_debug_state_machine: true,
+    transitions: {
+        *State1 + Event1(i32) / action1 = State2(i32),
+        // ...
+    }
+}
+
+/// Context
+#[derive(Debug)]
+pub struct Context;
+
+impl StateMachineContext for Context {
+    fn action1(&mut self, event_data:i32) -> i32 {
+        event_data * 2
+    }
+}
+
+fn main() {
+    let mut sm = StateMachine::new(Context);
+
+    {
+        let state = sm.state().unwrap();
+        assert_eq!(format!("{sm:?}"), "StateMachine { state: Some(State1), context: Context }");
+        assert_eq!(format!("{state:?}"), "State1");
+        assert_eq!(format!("{state}"), "State1");
+    }
+
+    {
+        let state = sm.process_event(Events::Event1(5)).unwrap();
+        assert!(matches!(state, &States::State2(10)));
+    }
+
+    {
+        let state = sm.state().unwrap();
+        assert_eq!(format!("{sm:?}"), "StateMachine { state: Some(State2(10)), context: Context }");
+        assert_eq!(format!("{state:?}"), "State2(10)");
+        assert_eq!(format!("{state}"), "State2(i32)");
+    }
+}

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -490,6 +490,43 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
         quote! {Error}
     };
 
+    let mut state_derives = Vec::new();
+
+    if sm.impl_debug_states {
+        state_derives.push(quote!{Debug});
+    }
+
+    let state_derives = if !state_derives.is_empty() {
+        quote!{#[derive(#(#state_derives),*)]}
+    } else {
+        quote!{}
+    };
+
+    let mut event_derives = Vec::new();
+
+    if sm.impl_debug_events {
+        event_derives.push(quote!{Debug});
+    }
+
+    let event_derives = if !event_derives.is_empty() {
+        quote!{#[derive(#(#event_derives),*)]}
+    } else {
+        quote!{}
+    };
+
+    let mut state_machine_derives = Vec::new();
+
+    if sm.impl_debug_state_machine {
+        state_machine_derives.push(quote!{Debug});
+    }
+
+    let state_machine_derives = if !state_machine_derives.is_empty() {
+        quote!{#[derive(#(#state_machine_derives),*)]}
+    } else {
+        quote!{}
+    };
+
+
     // Build the states and events output
     quote! {
         /// This trait outlines the guards and actions that need to be implemented for the state
@@ -503,6 +540,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
 
         /// List of auto-generated states.
         #[allow(missing_docs)]
+        #state_derives
         pub enum States <#state_lifetimes> { #(#state_list),* }
 
         #state_display
@@ -517,6 +555,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
 
         /// List of auto-generated events.
         #[allow(missing_docs)]
+        #event_derives
         pub enum Events <#event_lifetimes> { #(#event_list),* }
 
         #event_display
@@ -544,6 +583,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
         }
 
         /// State machine structure definition.
+        #state_machine_derives
         pub struct StateMachine<#state_lifetimes T: StateMachineContext> {
             state: Option<States <#state_lifetimes>>,
             context: T

--- a/macros/src/parser/mod.rs
+++ b/macros/src/parser/mod.rs
@@ -29,8 +29,11 @@ pub struct AsyncIdent {
 pub struct ParsedStateMachine {
     pub temporary_context_type: Option<Type>,
     pub custom_guard_error: bool,
+    pub impl_debug_events: bool,
+    pub impl_debug_states: bool,
     pub impl_display_events: bool,
     pub impl_display_states: bool,
+    pub impl_debug_state_machine: bool,
     pub states: HashMap<String, Ident>,
     pub starting_state: Ident,
     pub state_data: DataDefinitions,
@@ -205,8 +208,11 @@ impl ParsedStateMachine {
             events,
             event_data,
             states_events_mapping,
+            impl_debug_events: sm.impl_debug_events,
+            impl_debug_states: sm.impl_debug_states,
             impl_display_events: sm.impl_display_events,
             impl_display_states: sm.impl_display_states,
+            impl_debug_state_machine: sm.impl_debug_state_machine,
         })
     }
 }

--- a/macros/src/parser/state_machine.rs
+++ b/macros/src/parser/state_machine.rs
@@ -5,8 +5,11 @@ use syn::{braced, parse, spanned::Spanned, token, Ident, Token, Type};
 pub struct StateMachine {
     pub temporary_context_type: Option<Type>,
     pub custom_guard_error: bool,
+    pub impl_debug_states: bool,
+    pub impl_debug_events: bool,
     pub impl_display_states: bool,
     pub impl_display_events: bool,
+    pub impl_debug_state_machine: bool,
     pub transitions: Vec<StateTransition>,
 }
 
@@ -15,8 +18,11 @@ impl StateMachine {
         StateMachine {
             temporary_context_type: None,
             custom_guard_error: false,
+            impl_debug_states: false,
+            impl_debug_events: false,
             impl_display_states: false,
             impl_display_events: false,
+            impl_debug_state_machine: false,
             transitions: Vec::new(),
         }
     }
@@ -78,6 +84,20 @@ impl parse::Parse for StateMachine {
                     }
 
                 }
+                "impl_debug_states" => {
+                    input.parse::<Token![:]>()?;
+                    let b: syn::LitBool = input.parse()?;
+                    if b.value {
+                        statemachine.impl_debug_states = true
+                    }
+                }
+                "impl_debug_events" => {
+                    input.parse::<Token![:]>()?;
+                    let b: syn::LitBool = input.parse()?;
+                    if b.value {
+                        statemachine.impl_debug_events = true
+                    }
+                }
                 "impl_display_states" => {
                     input.parse::<Token![:]>()?;
                     let b: syn::LitBool = input.parse()?;
@@ -90,6 +110,13 @@ impl parse::Parse for StateMachine {
                     let b: syn::LitBool = input.parse()?;
                     if b.value {
                         statemachine.impl_display_events = true
+                    }
+                }
+                "impl_debug_state_machine" => {
+                    input.parse::<Token![:]>()?;
+                    let b: syn::LitBool = input.parse()?;
+                    if b.value {
+                        statemachine.impl_debug_state_machine = true
                     }
                 }
                 "temporary_context" => {


### PR DESCRIPTION
The macro supports derive(Display), but it doesn't support derive(Debug).
Added three flags - for Events, States, and StateMachine - to allow this.
Also added an example for testing and to show its usage.

A generic derive flag wasn't added, since that didn't match the existing pattern.