### PR TITLE
Add hooks for logging events, guards, actions, and state transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for async guards and actions
 - Add name to statemachine and make dot output stable and unique ([issue-62](https://github.com/korken89/smlang-rs/pull/62))
 - Add derive macros to states and events ([issue-62](https://github.com/korken89/smlang-rs/pull/62))
+- Add hooks to `StateMachineContext` for logging events, guards, actions, and state changes
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ println!("Sending event: {}", Events::Event1);
 
 ```
 
+### Hooks for logging events, guards, actions, and state transitions
+
+The `StateMachineContext` trait defines (and provides default, no-op implementations for) functions that are called for each event, guard, action, and state transition. You can provide your
+own implementations which plug into your preferred logging mechanism.
+
+```rust
+fn log_process_event(&self, current_state: &States, event: &Events) {}
+fn log_guard(&self, guard: &'static str, result: &Result<(), ()>) {}
+fn log_action(&self, action: &'static str) {}
+fn log_state_change(&self, new_state: &States) {}
+```
+
+See `examples/state_machine_logger.rs` for an example which uses `derive_states` and `derive_events` to derive `Debug` implementations for easy logging.
+
 ## Contributors
 
 List of contributors in alphabetical order:

--- a/examples/state_machine_logger.rs
+++ b/examples/state_machine_logger.rs
@@ -1,0 +1,112 @@
+//! State machine logger example
+//!
+//! An example of using the logging hooks on the `StateMachineContext` trait to automatically log
+//! events, guards, actions, and state transitions
+
+#![deny(missing_docs)]
+
+use smlang::statemachine;
+
+/// Event data
+#[derive(PartialEq, Debug)]
+pub struct MyEventData(pub u32);
+
+/// State data
+#[derive(PartialEq, Debug)]
+pub struct MyStateData(pub u32);
+
+statemachine! {
+    derive_states: [Debug],
+    derive_events: [Debug],
+    transitions: {
+        *State1 + Event1(MyEventData) [guard1] / action1 = State2,
+        State2(MyStateData) + Event2  [guard2] / action2 = State3,
+        // ...
+    }
+}
+
+/// Context
+pub struct Context;
+
+impl StateMachineContext for Context {
+    // Guard1 has access to the data from Event1
+    fn guard1(&mut self, event_data: &MyEventData) -> Result<(), ()> {
+        if event_data.0 % 2 == 0 {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    // Action1 has access to the data from Event1, and need to return the state data for State2
+    fn action1(&mut self, event_data: MyEventData) -> MyStateData {
+        println!("Creating state data for next state");
+        MyStateData(event_data.0)
+    }
+
+    // Guard2 has access to the data from State2
+    fn guard2(&mut self, state_data: &MyStateData) -> Result<(), ()> {
+        if state_data.0 % 2 == 0 {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    // Action2 has access to the data from State2
+    fn action2(&mut self, state_data: MyStateData) {
+        println!("Printing state data {:?}", state_data);
+    }
+
+    fn log_process_event(&self, current_state: &States, event: &Events) {
+        println!(
+            "[StateMachineLogger][{:?}] Processing event {:?}",
+            current_state, event
+        );
+    }
+
+    fn log_guard(&self, guard: &'static str, result: &Result<(), ()>) {
+        if result.is_ok() {
+            println!("[StateMachineLogger]\tPassed `{}`", guard);
+        } else {
+            println!("[StateMachineLogger]\tFailed `{}`", guard);
+        }
+    }
+
+    fn log_action(&self, action: &'static str) {
+        println!("[StateMachineLogger]\tRunning `{}`", action);
+    }
+
+    fn log_state_change(&self, new_state: &States) {
+        println!("[StateMachineLogger]\tTransitioning to {:?}", new_state);
+    }
+}
+
+fn main() {
+    let mut sm = StateMachine::new(Context);
+
+    let events = [
+        Events::Event1(MyEventData(1)),
+        Events::Event1(MyEventData(0)),
+        Events::Event2,
+    ];
+
+    for event in events {
+        let _ = sm.process_event(event);
+    }
+
+    /* $ cargo run --example state_machine_logger
+    [StateMachineLogger][State1] Processing event Event1(MyEventData(1))
+    [StateMachineLogger]    Failed `guard1`
+    [StateMachineLogger][State1] Processing event Event1(MyEventData(0))
+    [StateMachineLogger]    Passed `guard1`
+    Creating state data for next state
+    [StateMachineLogger]    Running `action1`
+    [StateMachineLogger]    Transitioning to State2(MyStateData(0))
+    [StateMachineLogger][State2(MyStateData(0))] Processing event Event2
+    [StateMachineLogger]    Passed `guard2`
+    Printing state data MyStateData(0)
+    [StateMachineLogger]    Running `action2`
+    [StateMachineLogger]    Transitioning to State3
+    */
+}


### PR DESCRIPTION
Boost.SML allows a user to provide a type which defines `log_process_event()`, `log_guard()`, `log_action()`, and `log_state_change()` functions that it'll call at the appropriate times ([docs](https://boost-ext.github.io/sml/examples.html#logging)). This PR builds something comparable for `smlang-rs` and exhibits its usage in `examples/state_machine_logger.rs`.

It's not an exact match with Boost.SML's:
- Boost.SML passes the event to `log_guard()` and `log_action()`
- Boost.SML passes the originating state to `log_state_transition()`
- Boost.SML does not pass the current state to `log_process_event()`

The deviations in this PR were to work around partial moves of state/event data. For example, partially moving data from the originating state into an action can be a prerequisite for creating the destination state. There wasn't an obvious way for `log_state_change()` to simultaneously access both. The example shows how this design can still be workable. It scratches my itch, anyway.