### PR TITLE
Removing redundant log_state_change function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ implementation.
 
 - [breaking] Renamed custom_guard_error flag to custom_error as it is not guard specific anymore
 - [breaking] Re-ordered on_exit/on_entry hooks calls
+- [breaking] New `transition_callback` has replaced `log_state_change` as it is more flexible.
 
 ## [0.7.0] - 2024-07-03
 

--- a/examples/state_machine_logger.rs
+++ b/examples/state_machine_logger.rs
@@ -53,7 +53,7 @@ impl StateMachineContext for Context {
 
     fn log_process_event(&self, current_state: &States, event: &Events) {
         println!(
-            "[StateMachineLogger][{:?}] Processing event {:?}",
+            "[StateMachineLogger]\t[{:?}] Processing event {:?}",
             current_state, event
         );
     }
@@ -70,8 +70,11 @@ impl StateMachineContext for Context {
         println!("[StateMachineLogger]\tRunning `{}`", action);
     }
 
-    fn log_state_change(&self, new_state: &States) {
-        println!("[StateMachineLogger]\tTransitioning to {:?}", new_state);
+    fn transition_callback(&self, old_state: &States, new_state: &States) {
+        println!(
+            "[StateMachineLogger]\tTransitioning {:?} -> {:?}",
+            old_state, new_state
+        );
     }
 }
 

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -425,7 +425,7 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
                                 is_async_state_machine |= is_async_action;
 
                                 let transition = if in_state_string == out_state_string {
-                                    // Stay in the same state => no need to call on_entry/on_exit and log_state_change
+                                    // Stay in the same state => no need to call on_entry/on_exit
                                     quote!{
                                             #action_code
                                             self.state = #states_type_name::#out_state;
@@ -436,7 +436,6 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
                                             self.context.#exit_ident();
                                             #action_code
                                             let out_state = #states_type_name::#out_state;
-                                            self.context.log_state_change(&out_state);
                                             self.context().transition_callback(&self.state, &out_state);
                                             self.state = out_state;
                                             self.context.#entry_ident();
@@ -567,11 +566,6 @@ pub fn generate_code(sm: &ParsedStateMachine) -> proc_macro2::TokenStream {
             /// default but can be overridden in implementations of a state machine's
             /// `StateMachineContext` trait.
             fn log_action(&self, action: &'static str) {}
-
-            /// Called when transitioning to a new state as a result of an event passed to
-            /// `process_event()`. No-op by default but can be overridden in implementations
-            /// of a state machine's `StateMachineContext` trait.
-            fn log_state_change(&self, new_state: & #states_type_name) {}
 
             /// Called when transitioning to a new state as a result of an event passed to
             /// `process_event()`. No-op by default which can be overridden in implementations


### PR DESCRIPTION
Removes the `log_state_change()` function, as this is now covered by `transition_callback`.

Once this lands, we can probably generate a new release.