### PR TITLE
macros: syn 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - [breaking] Remove `derive_states` and `derive_events` fields in lieu of `states_attr` and `events_attr` to define attributes generically
+- Bumped `syn` dependency to version 2
 
 ## [v0.8.0] - 2024-08-07
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -20,4 +20,4 @@ syn = "2"
 proc-macro = true
 
 [features]
-graphviz = []
+graphviz = ["syn/extra-traits"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,10 +14,7 @@ readme = "../README.md"
 quote = "1"
 proc-macro2 = "1"
 string_morph = "0.1.0"
-
-[dependencies.syn]
-features = ["extra-traits", "full"]
-version = "2"
+syn = "2"
 
 [lib]
 proc-macro = true

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,7 +17,7 @@ string_morph = "0.1.0"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
-version = "1"
+version = "2"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This bumps the `syn` dependency to major version 2.
It also removes the optional features from the `syn` dependency as they are not needed.

`syn` is a large crate and -- especially with the `full` features -- requires a bit of time to compile.
The majority of crates (dependents on on crates.io and the projects that I'm looking at) use `syn` 2. Trying to remove the `syn` 1 dependencies and unneeded features speeds up compile time.